### PR TITLE
Liquid template translations and message extraction

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,11 +4,11 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-python-liquid = "*"
 babel = "*"
 pytz = "*"
 python-dateutil = "*"
 markupsafe = "*"
+python-liquid = "*"
 
 [dev-packages]
 black = "*"
@@ -22,8 +22,8 @@ twine = "*"
 build = "*"
 liquid-babel = {editable = true, path = "."}
 ipython = "*"
-python-liquid-extra = "*"
 types-python-dateutil = "*"
+tox = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ python-liquid = "*"
 babel = "*"
 pytz = "*"
 python-dateutil = "*"
+markupsafe = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ pytz = "*"
 python-dateutil = "*"
 markupsafe = "*"
 python-liquid = "*"
+typing-extensions = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6995334b155fe69fe2e904258333505447337fbb84c8790aef782b8cb62a3dad"
+            "sha256": "8c05bb7db9ec4d21191c7e9a2e3b27dd82f005665e79ccfe31c4470a54693e8a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -24,6 +24,52 @@
             "index": "pypi",
             "version": "==2.10.3"
         },
+        "markupsafe": {
+            "hashes": [
+                "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003",
+                "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88",
+                "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5",
+                "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7",
+                "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a",
+                "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603",
+                "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1",
+                "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135",
+                "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247",
+                "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6",
+                "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601",
+                "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77",
+                "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02",
+                "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e",
+                "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63",
+                "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f",
+                "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980",
+                "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b",
+                "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812",
+                "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff",
+                "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96",
+                "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1",
+                "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925",
+                "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a",
+                "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6",
+                "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e",
+                "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f",
+                "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4",
+                "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
+                "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3",
+                "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c",
+                "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a",
+                "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417",
+                "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
+                "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a",
+                "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37",
+                "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452",
+                "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933",
+                "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
+                "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"
+            ],
+            "index": "pypi",
+            "version": "==2.1.1"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
@@ -34,19 +80,19 @@
         },
         "python-liquid": {
             "hashes": [
-                "sha256:472af4c9753d0b1dbea26d75636feb7d9a635e8d88a5a395ede778824ff239b0",
-                "sha256:ea53378a568b60818944891ddc76e52e5fda88d33546e2fe95da4421049516a2"
+                "sha256:296d2816acd75eaaf76cf17a0455fe8efb531e78fbd0b8017c76c9e99ff79940",
+                "sha256:3c1de31d866c09369cb48c5f61b0ac0b43339b20a26abae45b9aafba663a3678"
             ],
             "index": "pypi",
-            "version": "==1.3.0"
+            "version": "==1.4.3"
         },
         "pytz": {
             "hashes": [
-                "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7",
-                "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"
+                "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197",
+                "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"
             ],
             "index": "pypi",
-            "version": "==2022.1"
+            "version": "==2022.2.1"
         },
         "six": {
             "hashes": [
@@ -76,10 +122,10 @@
         },
         "asttokens": {
             "hashes": [
-                "sha256:0844691e88552595a6f4a4281a9f7f79b8dd45ca4ccea82e5e05b4bbdb76705c",
-                "sha256:9a54c114f02c7a9480d56550932546a3f1fe71d8a02f1bc7ccd0ee3ee35cf4d5"
+                "sha256:c61e16246ecfb2cde2958406b4c8ebc043c9e6d73aaa83c941673b35e5d3a76b",
+                "sha256:e3305297c744ae53ffa032c45dc347286165e4ffce6875dc662b205db0623d86"
             ],
-            "version": "==2.0.5"
+            "version": "==2.0.8"
         },
         "attrs": {
             "hashes": [
@@ -106,32 +152,32 @@
         },
         "black": {
             "hashes": [
-                "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90",
-                "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c",
-                "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78",
-                "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4",
-                "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee",
-                "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e",
-                "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e",
-                "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6",
-                "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9",
-                "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c",
-                "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256",
-                "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f",
-                "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2",
-                "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c",
-                "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b",
-                "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807",
-                "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf",
-                "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def",
-                "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad",
-                "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d",
-                "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849",
-                "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69",
-                "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"
+                "sha256:0a12e4e1353819af41df998b02c6742643cfef58282915f781d0e4dd7a200411",
+                "sha256:0ad827325a3a634bae88ae7747db1a395d5ee02cf05d9aa7a9bd77dfb10e940c",
+                "sha256:32a4b17f644fc288c6ee2bafdf5e3b045f4eff84693ac069d87b1a347d861497",
+                "sha256:3b2c25f8dea5e8444bdc6788a2f543e1fb01494e144480bc17f806178378005e",
+                "sha256:4a098a69a02596e1f2a58a2a1c8d5a05d5a74461af552b371e82f9fa4ada8342",
+                "sha256:5107ea36b2b61917956d018bd25129baf9ad1125e39324a9b18248d362156a27",
+                "sha256:53198e28a1fb865e9fe97f88220da2e44df6da82b18833b588b1883b16bb5d41",
+                "sha256:5594efbdc35426e35a7defa1ea1a1cb97c7dbd34c0e49af7fb593a36bd45edab",
+                "sha256:5b879eb439094751185d1cfdca43023bc6786bd3c60372462b6f051efa6281a5",
+                "sha256:78dd85caaab7c3153054756b9fe8c611efa63d9e7aecfa33e533060cb14b6d16",
+                "sha256:792f7eb540ba9a17e8656538701d3eb1afcb134e3b45b71f20b25c77a8db7e6e",
+                "sha256:8ce13ffed7e66dda0da3e0b2eb1bdfc83f5812f66e09aca2b0978593ed636b6c",
+                "sha256:a05da0430bd5ced89176db098567973be52ce175a55677436a271102d7eaa3fe",
+                "sha256:a983526af1bea1e4cf6768e649990f28ee4f4137266921c2c3cee8116ae42ec3",
+                "sha256:bc4d4123830a2d190e9cc42a2e43570f82ace35c3aeb26a512a2102bce5af7ec",
+                "sha256:c3a73f66b6d5ba7288cd5d6dad9b4c9b43f4e8a4b789a94bf5abfb878c663eb3",
+                "sha256:ce957f1d6b78a8a231b18e0dd2d94a33d2ba738cd88a7fe64f53f659eea49fdd",
+                "sha256:cea1b2542d4e2c02c332e83150e41e3ca80dc0fb8de20df3c5e98e242156222c",
+                "sha256:d2c21d439b2baf7aa80d6dd4e3659259be64c6f49dfd0f32091063db0e006db4",
+                "sha256:d839150f61d09e7217f52917259831fe2b689f5c8e5e32611736351b89bb2a90",
+                "sha256:dd82842bb272297503cbec1a2600b6bfb338dae017186f8f215c8958f8acf869",
+                "sha256:e8166b7bfe5dcb56d325385bd1d1e0f635f24aae14b3ae437102dedc0c186747",
+                "sha256:e981e20ec152dfb3e77418fb616077937378b322d7b26aa1ff87717fb18b4875"
             ],
             "index": "pypi",
-            "version": "==22.6.0"
+            "version": "==22.8.0"
         },
         "bleach": {
             "hashes": [
@@ -228,11 +274,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
-                "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"
+                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
+                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.1.0"
+            "version": "==2.1.1"
         },
         "click": {
             "hashes": [
@@ -251,50 +297,59 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:0895ea6e6f7f9939166cc835df8fa4599e2d9b759b02d1521b574e13b859ac32",
-                "sha256:0f211df2cba951ffcae210ee00e54921ab42e2b64e0bf2c0befc977377fb09b7",
-                "sha256:147605e1702d996279bb3cc3b164f408698850011210d133a2cb96a73a2f7996",
-                "sha256:24b04d305ea172ccb21bee5bacd559383cba2c6fcdef85b7701cf2de4188aa55",
-                "sha256:25b7ec944f114f70803d6529394b64f8749e93cbfac0fe6c5ea1b7e6c14e8a46",
-                "sha256:2b20286c2b726f94e766e86a3fddb7b7e37af5d0c635bdfa7e4399bc523563de",
-                "sha256:2dff52b3e7f76ada36f82124703f4953186d9029d00d6287f17c68a75e2e6039",
-                "sha256:2f8553878a24b00d5ab04b7a92a2af50409247ca5c4b7a2bf4eabe94ed20d3ee",
-                "sha256:3def6791adf580d66f025223078dc84c64696a26f174131059ce8e91452584e1",
-                "sha256:422fa44070b42fef9fb8dabd5af03861708cdd6deb69463adc2130b7bf81332f",
-                "sha256:4f89d8e03c8a3757aae65570d14033e8edf192ee9298303db15955cadcff0c63",
-                "sha256:5336e0352c0b12c7e72727d50ff02557005f79a0b8dcad9219c7c4940a930083",
-                "sha256:54d8d0e073a7f238f0666d3c7c0d37469b2aa43311e4024c925ee14f5d5a1cbe",
-                "sha256:5ef42e1db047ca42827a85e34abe973971c635f83aed49611b7f3ab49d0130f0",
-                "sha256:5f65e5d3ff2d895dab76b1faca4586b970a99b5d4b24e9aafffc0ce94a6022d6",
-                "sha256:6c3ccfe89c36f3e5b9837b9ee507472310164f352c9fe332120b764c9d60adbe",
-                "sha256:6d0b48aff8e9720bdec315d67723f0babd936a7211dc5df453ddf76f89c59933",
-                "sha256:6fe75dcfcb889b6800f072f2af5a331342d63d0c1b3d2bf0f7b4f6c353e8c9c0",
-                "sha256:79419370d6a637cb18553ecb25228893966bd7935a9120fa454e7076f13b627c",
-                "sha256:7bb00521ab4f99fdce2d5c05a91bddc0280f0afaee0e0a00425e28e209d4af07",
-                "sha256:80db4a47a199c4563d4a25919ff29c97c87569130375beca3483b41ad5f698e8",
-                "sha256:866ebf42b4c5dbafd64455b0a1cd5aa7b4837a894809413b930026c91e18090b",
-                "sha256:8af6c26ba8df6338e57bedbf916d76bdae6308e57fc8f14397f03b5da8622b4e",
-                "sha256:a13772c19619118903d65a91f1d5fea84be494d12fd406d06c849b00d31bf120",
-                "sha256:a697977157adc052284a7160569b36a8bbec09db3c3220642e6323b47cec090f",
-                "sha256:a9032f9b7d38bdf882ac9f66ebde3afb8145f0d4c24b2e600bc4c6304aafb87e",
-                "sha256:b5e28db9199dd3833cc8a07fa6cf429a01227b5d429facb56eccd765050c26cd",
-                "sha256:c77943ef768276b61c96a3eb854eba55633c7a3fddf0a79f82805f232326d33f",
-                "sha256:d230d333b0be8042ac34808ad722eabba30036232e7a6fb3e317c49f61c93386",
-                "sha256:d4548be38a1c810d79e097a38107b6bf2ff42151900e47d49635be69943763d8",
-                "sha256:d4e7ced84a11c10160c0697a6cc0b214a5d7ab21dfec1cd46e89fbf77cc66fae",
-                "sha256:d56f105592188ce7a797b2bd94b4a8cb2e36d5d9b0d8a1d2060ff2a71e6b9bbc",
-                "sha256:d714af0bdba67739598849c9f18efdcc5a0412f4993914a0ec5ce0f1e864d783",
-                "sha256:d774d9e97007b018a651eadc1b3970ed20237395527e22cbeb743d8e73e0563d",
-                "sha256:e0524adb49c716ca763dbc1d27bedce36b14f33e6b8af6dba56886476b42957c",
-                "sha256:e2618cb2cf5a7cc8d698306e42ebcacd02fb7ef8cfc18485c59394152c70be97",
-                "sha256:e36750fbbc422c1c46c9d13b937ab437138b998fe74a635ec88989afb57a3978",
-                "sha256:edfdabe7aa4f97ed2b9dd5dde52d2bb29cb466993bb9d612ddd10d0085a683cf",
-                "sha256:f22325010d8824594820d6ce84fa830838f581a7fd86a9235f0d2ed6deb61e29",
-                "sha256:f23876b018dfa5d3e98e96f5644b109090f16a4acb22064e0f06933663005d39",
-                "sha256:f7bd0ffbcd03dc39490a1f40b2669cc414fae0c4e16b77bb26806a4d0b7d1452"
+                "sha256:01778769097dbd705a24e221f42be885c544bb91251747a8a3efdec6eb4788f2",
+                "sha256:08002f9251f51afdcc5e3adf5d5d66bb490ae893d9e21359b085f0e03390a820",
+                "sha256:1238b08f3576201ebf41f7c20bf59baa0d05da941b123c6656e42cdb668e9827",
+                "sha256:14a32ec68d721c3d714d9b105c7acf8e0f8a4f4734c811eda75ff3718570b5e3",
+                "sha256:15e38d853ee224e92ccc9a851457fb1e1f12d7a5df5ae44544ce7863691c7a0d",
+                "sha256:354df19fefd03b9a13132fa6643527ef7905712109d9c1c1903f2133d3a4e145",
+                "sha256:35ef1f8d8a7a275aa7410d2f2c60fa6443f4a64fae9be671ec0696a68525b875",
+                "sha256:4179502f210ebed3ccfe2f78bf8e2d59e50b297b598b100d6c6e3341053066a2",
+                "sha256:42c499c14efd858b98c4e03595bf914089b98400d30789511577aa44607a1b74",
+                "sha256:4b7101938584d67e6f45f0015b60e24a95bf8dea19836b1709a80342e01b472f",
+                "sha256:564cd0f5b5470094df06fab676c6d77547abfdcb09b6c29c8a97c41ad03b103c",
+                "sha256:5f444627b3664b80d078c05fe6a850dd711beeb90d26731f11d492dcbadb6973",
+                "sha256:6113e4df2fa73b80f77663445be6d567913fb3b82a86ceb64e44ae0e4b695de1",
+                "sha256:61b993f3998ee384935ee423c3d40894e93277f12482f6e777642a0141f55782",
+                "sha256:66e6df3ac4659a435677d8cd40e8eb1ac7219345d27c41145991ee9bf4b806a0",
+                "sha256:67f9346aeebea54e845d29b487eb38ec95f2ecf3558a3cffb26ee3f0dcc3e760",
+                "sha256:6913dddee2deff8ab2512639c5168c3e80b3ebb0f818fed22048ee46f735351a",
+                "sha256:6a864733b22d3081749450466ac80698fe39c91cb6849b2ef8752fd7482011f3",
+                "sha256:7026f5afe0d1a933685d8f2169d7c2d2e624f6255fb584ca99ccca8c0e966fd7",
+                "sha256:783bc7c4ee524039ca13b6d9b4186a67f8e63d91342c713e88c1865a38d0892a",
+                "sha256:7a98d6bf6d4ca5c07a600c7b4e0c5350cd483c85c736c522b786be90ea5bac4f",
+                "sha256:8d032bfc562a52318ae05047a6eb801ff31ccee172dc0d2504614e911d8fa83e",
+                "sha256:98c0b9e9b572893cdb0a00e66cf961a238f8d870d4e1dc8e679eb8bdc2eb1b86",
+                "sha256:9c7b9b498eb0c0d48b4c2abc0e10c2d78912203f972e0e63e3c9dc21f15abdaa",
+                "sha256:9cc4f107009bca5a81caef2fca843dbec4215c05e917a59dec0c8db5cff1d2aa",
+                "sha256:9d6e1f3185cbfd3d91ac77ea065d85d5215d3dfa45b191d14ddfcd952fa53796",
+                "sha256:a095aa0a996ea08b10580908e88fbaf81ecf798e923bbe64fb98d1807db3d68a",
+                "sha256:a3b2752de32c455f2521a51bd3ffb53c5b3ae92736afde67ce83477f5c1dd928",
+                "sha256:ab066f5ab67059d1f1000b5e1aa8bbd75b6ed1fc0014559aea41a9eb66fc2ce0",
+                "sha256:c1328d0c2f194ffda30a45f11058c02410e679456276bfa0bbe0b0ee87225fac",
+                "sha256:c35cca192ba700979d20ac43024a82b9b32a60da2f983bec6c0f5b84aead635c",
+                "sha256:cbbb0e4cd8ddcd5ef47641cfac97d8473ab6b132dd9a46bacb18872828031685",
+                "sha256:cdbb0d89923c80dbd435b9cf8bba0ff55585a3cdb28cbec65f376c041472c60d",
+                "sha256:cf2afe83a53f77aec067033199797832617890e15bed42f4a1a93ea24794ae3e",
+                "sha256:d5dd4b8e9cd0deb60e6fcc7b0647cbc1da6c33b9e786f9c79721fd303994832f",
+                "sha256:dfa0b97eb904255e2ab24166071b27408f1f69c8fbda58e9c0972804851e0558",
+                "sha256:e16c45b726acb780e1e6f88b286d3c10b3914ab03438f32117c4aa52d7f30d58",
+                "sha256:e1fabd473566fce2cf18ea41171d92814e4ef1495e04471786cbc943b89a3781",
+                "sha256:e3d3c4cc38b2882f9a15bafd30aec079582b819bec1b8afdbde8f7797008108a",
+                "sha256:e431e305a1f3126477abe9a184624a85308da8edf8486a863601d58419d26ffa",
+                "sha256:e7b4da9bafad21ea45a714d3ea6f3e1679099e420c8741c74905b92ee9bfa7cc",
+                "sha256:ee2b2fb6eb4ace35805f434e0f6409444e1466a47f620d1d5763a22600f0f892",
+                "sha256:ee6ae6bbcac0786807295e9687169fba80cb0617852b2fa118a99667e8e6815d",
+                "sha256:ef6f44409ab02e202b31a05dd6666797f9de2aa2b4b3534e9d450e42dea5e817",
+                "sha256:f67cf9f406cf0d2f08a3515ce2db5b82625a7257f88aad87904674def6ddaec1",
+                "sha256:f855b39e4f75abd0dfbcf74a82e84ae3fc260d523fcb3532786bcbbcb158322c",
+                "sha256:fc600f6ec19b273da1d85817eda339fb46ce9eef3e89f220055d8696e0a06908",
+                "sha256:fcbe3d9a53e013f8ab88734d7e517eb2cd06b7e689bedf22c0eb68db5e4a0a19",
+                "sha256:fde17bc42e0716c94bf19d92e4c9f5a00c5feb401f5bc01101fdf2a8b7cacf60",
+                "sha256:ff934ced84054b9018665ca3967fc48e1ac99e811f6cc99ea65978e1d384454b"
             ],
             "index": "pypi",
-            "version": "==6.4.2"
+            "version": "==6.4.4"
         },
         "cryptography": {
             "hashes": [
@@ -350,18 +405,18 @@
         },
         "executing": {
             "hashes": [
-                "sha256:4ce4d6082d99361c0231fc31ac1a0f56979363cc6819de0b1410784f99e49105",
-                "sha256:ea278e2cf90cbbacd24f1080dd1f0ac25b71b2e21f50ab439b7ba45dd3195587"
+                "sha256:550d581b497228b572235e633599133eeee67073c65914ca346100ad56775349",
+                "sha256:98daefa9d1916a4f0d944880d5aeaf079e05585689bebd9ff9b32e31dd5e1017"
             ],
-            "version": "==0.9.1"
+            "version": "==1.0.0"
         },
         "flake8": {
             "hashes": [
-                "sha256:44e3ecd719bba1cb2ae65d1b54212cc9df4f5db15ac271f8856e5e6c2eebefed",
-                "sha256:9c51d3d1426379fd444d3b79eabbeb887849368bd053039066439523d8486961"
+                "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db",
+                "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"
             ],
             "index": "pypi",
-            "version": "==5.0.1"
+            "version": "==5.0.4"
         },
         "idna": {
             "hashes": [
@@ -402,6 +457,14 @@
             "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
             "version": "==5.10.1"
         },
+        "jaraco.classes": {
+            "hashes": [
+                "sha256:6745f113b0b588239ceb49532aa09c3ebb947433ce311ef2f8e3ad64ebb74594",
+                "sha256:e6ef6fd3fcf4579a7a019d87d1e56a883f4e4c35cfe925f86731abc58804e647"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.2.2"
+        },
         "jedi": {
             "hashes": [
                 "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d",
@@ -420,11 +483,11 @@
         },
         "keyring": {
             "hashes": [
-                "sha256:782e1cd1132e91bf459fcd243bcf25b326015c1ac0b198e4408f91fa6791062b",
-                "sha256:e67fc91a7955785fd2efcbccdd72d7dacf136dbc381d27de305b2b660b3de886"
+                "sha256:4c32a31174faaee48f43a7e2c7e9c3216ec5e95acf22a2bebfb4a1d05056ee44",
+                "sha256:98f060ec95ada2ab910c195a2d4317be6ef87936a766b239c46aa3c7aac4f0db"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.7.0"
+            "version": "==23.9.0"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -475,11 +538,11 @@
         },
         "matplotlib-inline": {
             "hashes": [
-                "sha256:a04bfba22e0d1395479f866853ec1ee28eea1485c1d69a6faf00dc3e24ff34ee",
-                "sha256:aed605ba3b72462d64d475a21a9296f400a19c4f74a31b59103d2a99ffd5aa5c"
+                "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311",
+                "sha256:f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==0.1.3"
+            "version": "==0.1.6"
         },
         "mccabe": {
             "hashes": [
@@ -488,6 +551,14 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==0.7.0"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:1bc4f91ee5b1b31ac7ceacc17c09befe6a40a503907baf9c839c229b5095cfd2",
+                "sha256:c09443cd3d5438b8dafccd867a6bc1cb0894389e90cb53d227456b0b0bccb750"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==8.14.0"
         },
         "mypy": {
             "hashes": [
@@ -543,10 +614,11 @@
         },
         "pathspec": {
             "hashes": [
-                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
-                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"
+                "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93",
+                "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"
             ],
-            "version": "==0.9.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.10.1"
         },
         "pep517": {
             "hashes": [
@@ -597,11 +669,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:859b283c50bde45f5f97829f77a4674d1c1fcd88539364f1b28a37805cfd89c0",
-                "sha256:d8916d3f62a7b67ab353a952ce4ced6a1d2587dfe9ef8ebc30dd7c386751f289"
+                "sha256:9696f386133df0fc8ca5af4895afe5d78f5fcfe5258111c2a79a1c3e41ffa96d",
+                "sha256:9ada952c9d1787f52ff6d5f3484d0b4df8952787c087edf6a1f7c2cb1ea88148"
             ],
             "markers": "python_full_version >= '3.6.2'",
-            "version": "==3.0.30"
+            "version": "==3.0.31"
         },
         "ptyprocess": {
             "hashes": [
@@ -627,11 +699,11 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:289cdc0969d589d90752582bef6dff57c5fbc6949ee8b013ad6d6449a8ae9437",
-                "sha256:beaba44501f89d785be791c9462553f06958a221d166c64e1f107320f839acc2"
+                "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785",
+                "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.9.0"
+            "version": "==2.9.1"
         },
         "pycparser": {
             "hashes": [
@@ -650,11 +722,11 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb",
-                "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"
+                "sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1",
+                "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.12.0"
+            "version": "==2.13.0"
         },
         "pylint": {
             "hashes": [
@@ -674,11 +746,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c",
-                "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"
+                "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
+                "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
             ],
             "index": "pypi",
-            "version": "==7.1.2"
+            "version": "==7.1.3"
         },
         "python-dateutil": {
             "hashes": [
@@ -690,11 +762,11 @@
         },
         "python-liquid": {
             "hashes": [
-                "sha256:472af4c9753d0b1dbea26d75636feb7d9a635e8d88a5a395ede778824ff239b0",
-                "sha256:ea53378a568b60818944891ddc76e52e5fda88d33546e2fe95da4421049516a2"
+                "sha256:296d2816acd75eaaf76cf17a0455fe8efb531e78fbd0b8017c76c9e99ff79940",
+                "sha256:3c1de31d866c09369cb48c5f61b0ac0b43339b20a26abae45b9aafba663a3678"
             ],
             "index": "pypi",
-            "version": "==1.3.0"
+            "version": "==1.4.3"
         },
         "python-liquid-extra": {
             "hashes": [
@@ -706,19 +778,19 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7",
-                "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"
+                "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197",
+                "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"
             ],
             "index": "pypi",
-            "version": "==2022.1"
+            "version": "==2022.2.1"
         },
         "readme-renderer": {
             "hashes": [
-                "sha256:73b84905d091c31f36e50b4ae05ae2acead661f6a09a9abb4df7d2ddcdb6a698",
-                "sha256:a727999acfc222fc21d82a12ed48c957c4989785e5865807c65a487d21677497"
+                "sha256:16c914ca7731fd062a316a2a8e5434a175ee34661a608af771a60c881f528a34",
+                "sha256:96768c069729f69176f514477e57f2f8cd543fbb2cd7bad372976249fa509a0c"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==35.0"
+            "version": "==37.1"
         },
         "requests": {
             "hashes": [
@@ -753,19 +825,19 @@
         },
         "secretstorage": {
             "hashes": [
-                "sha256:0a8eb9645b320881c222e827c26f4cfcf55363e8b374a021981ef886657a912f",
-                "sha256:755dc845b6ad76dcbcbc07ea3da75ae54bb1ea529eb72d15f83d26499a5df319"
+                "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77",
+                "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99"
             ],
             "markers": "sys_platform == 'linux'",
-            "version": "==3.3.2"
+            "version": "==3.3.3"
         },
         "setuptools": {
             "hashes": [
-                "sha256:273b6847ae61f7829c1affcdd9a32f67aa65233be508f4fbaab866c5faa4e408",
-                "sha256:d5340d16943a0f67057329db59b564e938bb3736c6e50ae16ea84d5e5d9ba6d0"
+                "sha256:2e24e0bec025f035a2e72cdd1961119f557d78ad331bb00ff82efb2ab8da8e82",
+                "sha256:7732871f4f7fa58fb6bdcaeadb0161b2bd046c85905dbaa066bdcbcc81953b57"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==63.3.0"
+            "version": "==65.3.0"
         },
         "six": {
             "hashes": [
@@ -777,10 +849,10 @@
         },
         "stack-data": {
             "hashes": [
-                "sha256:77bec1402dcd0987e9022326473fdbcc767304892a533ed8c29888dacb7dddbc",
-                "sha256:aa1d52d14d09c7a9a12bb740e6bdfffe0f5e8f4f9218d85e7c73a8c37f7ae38d"
+                "sha256:66d2ebd3d7f29047612ead465b6cae5371006a71f45037c7e2507d01367bce3b",
+                "sha256:715c8855fbf5c43587b141e46cc9d9339cc0d1f8d6e0f98ed0d01c6cb974e29f"
             ],
-            "version": "==0.3.0"
+            "version": "==0.5.0"
         },
         "tomli": {
             "hashes": [
@@ -792,11 +864,11 @@
         },
         "tomlkit": {
             "hashes": [
-                "sha256:1c5bebdf19d5051e2e1de6cf70adfc5948d47221f097fcff7a3ffc91e953eaf5",
-                "sha256:61901f81ff4017951119cd0d1ed9b7af31c821d6845c8c477587bbdcd5e5854e"
+                "sha256:25d4e2e446c453be6360c67ddfb88838cfc42026322770ba13d1fbd403a93a5c",
+                "sha256:3235a9010fae54323e727c3ac06fb720752fe6635b3426e379daec60fbd44a83"
             ],
             "markers": "python_version >= '3.6' and python_version < '4.0'",
-            "version": "==0.11.1"
+            "version": "==0.11.4"
         },
         "traitlets": {
             "hashes": [
@@ -832,10 +904,10 @@
         },
         "types-pytz": {
             "hashes": [
-                "sha256:1a8b25c225c5e6bd8468aa9eb45ddd3b337f6716d4072ad0aa4ef1e41478eebc",
-                "sha256:8aa9fd2af9dee5f5bd7221c6804c9addeafa7ebc0008f544d4ace02b066818a4"
+                "sha256:47cfb19c52b9f75896440541db392fd312a35b279c6307a531db71152ea63e2b",
+                "sha256:50ead2254b524a3d4153bc65d00289b66898060d2938e586170dce918dbaf3b3"
             ],
-            "version": "==2022.1.2"
+            "version": "==2022.2.1.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -847,11 +919,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc",
-                "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"
+                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
+                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4.0'",
-            "version": "==1.26.11"
+            "version": "==1.26.12"
         },
         "wcwidth": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8c05bb7db9ec4d21191c7e9a2e3b27dd82f005665e79ccfe31c4470a54693e8a"
+            "sha256": "fc6e1a4c637388e2baddfe36c88dc0d143f8a6c946f6f379980a7ebae46ea5da"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -80,11 +80,11 @@
         },
         "python-liquid": {
             "hashes": [
-                "sha256:296d2816acd75eaaf76cf17a0455fe8efb531e78fbd0b8017c76c9e99ff79940",
-                "sha256:3c1de31d866c09369cb48c5f61b0ac0b43339b20a26abae45b9aafba663a3678"
+                "sha256:acd43dedeb1d20d1ca19f8b0ef544882198960b151435813c68cc26bedc7651c",
+                "sha256:c367b4dec3e52621b87a7475418bf505a1774665529b3bc7364a9bf8afb8e022"
             ],
             "index": "pypi",
-            "version": "==1.4.3"
+            "version": "==1.4.5"
         },
         "pytz": {
             "hashes": [
@@ -195,13 +195,21 @@
             "index": "pypi",
             "version": "==0.8.0"
         },
+        "cachetools": {
+            "hashes": [
+                "sha256:6a94c6402995a99c3970cc7e4884bb60b4a8639938157eeed436098bf9831757",
+                "sha256:f9f17d2aec496a9aa6b76f53e3b614c965223c061982d434d160f930c698a9db"
+            ],
+            "markers": "python_version ~= '3.7'",
+            "version": "==5.2.0"
+        },
         "certifi": {
             "hashes": [
-                "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
-                "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
+                "sha256:43dadad18a7f168740e66944e4fa82c6611848ff9056ad910f8f7a3e46ab89e0",
+                "sha256:cffdcd380919da6137f76633531a5817e3a9f268575c128249fb637e4f9e73fb"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.6.15"
+            "version": "==2022.6.15.1"
         },
         "cffi": {
             "hashes": [
@@ -272,6 +280,14 @@
             ],
             "version": "==1.15.1"
         },
+        "chardet": {
+            "hashes": [
+                "sha256:0368df2bfd78b5fc20572bb4e9bb7fb53e2c094f60ae9993339e8671d0afb8aa",
+                "sha256:d3e64f022d254183001eccc5db4040520c0f23b1a3f33d6413e099eb7f126557"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==5.0.0"
+        },
         "charset-normalizer": {
             "hashes": [
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
@@ -287,6 +303,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.1.3"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da",
+                "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.4.5"
         },
         "commonmark": {
             "hashes": [
@@ -353,31 +377,35 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:190f82f3e87033821828f60787cfa42bff98404483577b591429ed99bed39d59",
-                "sha256:2be53f9f5505673eeda5f2736bea736c40f051a739bfae2f92d18aed1eb54596",
-                "sha256:30788e070800fec9bbcf9faa71ea6d8068f5136f60029759fd8c3efec3c9dcb3",
-                "sha256:3d41b965b3380f10e4611dbae366f6dc3cefc7c9ac4e8842a806b9672ae9add5",
-                "sha256:4c590ec31550a724ef893c50f9a97a0c14e9c851c85621c5650d699a7b88f7ab",
-                "sha256:549153378611c0cca1042f20fd9c5030d37a72f634c9326e225c9f666d472884",
-                "sha256:63f9c17c0e2474ccbebc9302ce2f07b55b3b3fcb211ded18a42d5764f5c10a82",
-                "sha256:6bc95ed67b6741b2607298f9ea4932ff157e570ef456ef7ff0ef4884a134cc4b",
-                "sha256:7099a8d55cd49b737ffc99c17de504f2257e3787e02abe6d1a6d136574873441",
-                "sha256:75976c217f10d48a8b5a8de3d70c454c249e4b91851f6838a4e48b8f41eb71aa",
-                "sha256:7bc997818309f56c0038a33b8da5c0bfbb3f1f067f315f9abd6fc07ad359398d",
-                "sha256:80f49023dd13ba35f7c34072fa17f604d2f19bf0989f292cedf7ab5770b87a0b",
-                "sha256:91ce48d35f4e3d3f1d83e29ef4a9267246e6a3be51864a5b7d2247d5086fa99a",
-                "sha256:a958c52505c8adf0d3822703078580d2c0456dd1d27fabfb6f76fe63d2971cd6",
-                "sha256:b62439d7cd1222f3da897e9a9fe53bbf5c104fff4d60893ad1355d4c14a24157",
-                "sha256:b7f8dd0d4c1f21759695c05a5ec8536c12f31611541f8904083f3dc582604280",
-                "sha256:d204833f3c8a33bbe11eda63a54b1aad7aa7456ed769a982f21ec599ba5fa282",
-                "sha256:e007f052ed10cc316df59bc90fbb7ff7950d7e2919c9757fd42a2b8ecf8a5f67",
-                "sha256:f2dcb0b3b63afb6df7fd94ec6fbddac81b5492513f7b0436210d390c14d46ee8",
-                "sha256:f721d1885ecae9078c3f6bbe8a88bc0786b6e749bf32ccec1ef2b18929a05046",
-                "sha256:f7a6de3e98771e183645181b3627e2563dcde3ce94a9e42a3f427d2255190327",
-                "sha256:f8c0a6e9e1dd3eb0414ba320f85da6b0dcbd543126e30fcc546e7372a7fbf3b9"
+                "sha256:0297ffc478bdd237f5ca3a7dc96fc0d315670bfa099c04dc3a4a2172008a405a",
+                "sha256:10d1f29d6292fc95acb597bacefd5b9e812099d75a6469004fd38ba5471a977f",
+                "sha256:16fa61e7481f4b77ef53991075de29fc5bacb582a1244046d2e8b4bb72ef66d0",
+                "sha256:194044c6b89a2f9f169df475cc167f6157eb9151cc69af8a2a163481d45cc407",
+                "sha256:1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7",
+                "sha256:3261725c0ef84e7592597606f6583385fed2a5ec3909f43bc475ade9729a41d6",
+                "sha256:3b72c360427889b40f36dc214630e688c2fe03e16c162ef0aa41da7ab1455153",
+                "sha256:3e3a2599e640927089f932295a9a247fc40a5bdf69b0484532f530471a382750",
+                "sha256:3fc26e22840b77326a764ceb5f02ca2d342305fba08f002a8c1f139540cdfaad",
+                "sha256:5067ee7f2bce36b11d0e334abcd1ccf8c541fc0bbdaf57cdd511fdee53e879b6",
+                "sha256:52e7bee800ec869b4031093875279f1ff2ed12c1e2f74923e8f49c916afd1d3b",
+                "sha256:64760ba5331e3f1794d0bcaabc0d0c39e8c60bf67d09c93dc0e54189dfd7cfe5",
+                "sha256:765fa194a0f3372d83005ab83ab35d7c5526c4e22951e46059b8ac678b44fa5a",
+                "sha256:79473cf8a5cbc471979bd9378c9f425384980fcf2ab6534b18ed7d0d9843987d",
+                "sha256:896dd3a66959d3a5ddcfc140a53391f69ff1e8f25d93f0e2e7830c6de90ceb9d",
+                "sha256:89ed49784ba88c221756ff4d4755dbc03b3c8d2c5103f6d6b4f83a0fb1e85294",
+                "sha256:ac7e48f7e7261207d750fa7e55eac2d45f720027d5703cd9007e9b37bbb59ac0",
+                "sha256:ad7353f6ddf285aeadfaf79e5a6829110106ff8189391704c1d8801aa0bae45a",
+                "sha256:b0163a849b6f315bf52815e238bc2b2346604413fa7c1601eea84bcddb5fb9ac",
+                "sha256:b6c9b706316d7b5a137c35e14f4103e2115b088c412140fdbd5f87c73284df61",
+                "sha256:c2e5856248a416767322c8668ef1845ad46ee62629266f84a8f007a317141013",
+                "sha256:ca9f6784ea96b55ff41708b92c3f6aeaebde4c560308e5fbbd3173fbc466e94e",
+                "sha256:d1a5bd52d684e49a36582193e0b89ff267704cd4025abefb9e26803adeb3e5fb",
+                "sha256:d3971e2749a723e9084dd507584e2a2761f78ad2c638aa31e80bc7a15c9db4f9",
+                "sha256:d4ef6cc305394ed669d4d9eebf10d3a101059bdcf2669c366ec1d14e4fb227bd",
+                "sha256:d9e69ae01f99abe6ad646947bba8941e896cb3aa805be2597a0400e0764b5818"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==37.0.4"
+            "version": "==38.0.1"
         },
         "decorator": {
             "hashes": [
@@ -395,6 +423,13 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
             "version": "==0.3.5.1"
         },
+        "distlib": {
+            "hashes": [
+                "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46",
+                "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"
+            ],
+            "version": "==0.3.6"
+        },
         "docutils": {
             "hashes": [
                 "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6",
@@ -409,6 +444,14 @@
                 "sha256:98daefa9d1916a4f0d944880d5aeaf079e05585689bebd9ff9b32e31dd5e1017"
             ],
             "version": "==1.0.0"
+        },
+        "filelock": {
+            "hashes": [
+                "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc",
+                "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.8.0"
         },
         "flake8": {
             "hashes": [
@@ -443,18 +486,18 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:7ca74052a38fa25fe9bedf52da0be7d3fdd2fb027c3b778ea78dfe8c212937d1",
-                "sha256:f2db3a10254241d9b447232cec8b424847f338d9d36f9a577a6192c332a46abd"
+                "sha256:097bdf5cd87576fd066179c9f7f208004f7a6864ee1b20f37d346c0bcb099f84",
+                "sha256:6f090e29ab8ef8643e521763a4f1f39dc3914db643122b1e9d3328ff2e43ada2"
             ],
             "index": "pypi",
-            "version": "==8.4.0"
+            "version": "==8.5.0"
         },
         "isort": {
             "hashes": [
                 "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
                 "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"
             ],
-            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
+            "markers": "python_full_version >= '3.6.1' and python_full_version < '4.0.0'",
             "version": "==5.10.1"
         },
         "jaraco.classes": {
@@ -483,11 +526,11 @@
         },
         "keyring": {
             "hashes": [
-                "sha256:4c32a31174faaee48f43a7e2c7e9c3216ec5e95acf22a2bebfb4a1d05056ee44",
-                "sha256:98f060ec95ada2ab910c195a2d4317be6ef87936a766b239c46aa3c7aac4f0db"
+                "sha256:3565b9e4ea004c96e158d2d332a49f466733d565bb24157a60fd2e49f41a0fd1",
+                "sha256:39e4f6572238d2615a82fcaa485e608b84b503cf080dc924c43bbbacb11c1c18"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.9.0"
+            "version": "==23.9.1"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -744,6 +787,14 @@
             "markers": "python_full_version >= '3.6.8'",
             "version": "==3.0.9"
         },
+        "pyproject-api": {
+            "hashes": [
+                "sha256:a760229e56ecb776728f1c2ff0e204d3582efc9582d3c20f9d492be75cc19aa8",
+                "sha256:d4e088384e993a0824cc0e207b14182c17ff59ab416419656422155243f59e05"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.1.1"
+        },
         "pytest": {
             "hashes": [
                 "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
@@ -762,19 +813,11 @@
         },
         "python-liquid": {
             "hashes": [
-                "sha256:296d2816acd75eaaf76cf17a0455fe8efb531e78fbd0b8017c76c9e99ff79940",
-                "sha256:3c1de31d866c09369cb48c5f61b0ac0b43339b20a26abae45b9aafba663a3678"
+                "sha256:acd43dedeb1d20d1ca19f8b0ef544882198960b151435813c68cc26bedc7651c",
+                "sha256:c367b4dec3e52621b87a7475418bf505a1774665529b3bc7364a9bf8afb8e022"
             ],
             "index": "pypi",
-            "version": "==1.4.3"
-        },
-        "python-liquid-extra": {
-            "hashes": [
-                "sha256:8615b6a506f58be0b389bf83f9f7ad48863ceccec162e9b41883783e7dfd57c0",
-                "sha256:c3765ed55473999f7b61976187af9f6c966ad89fc17faae6ecc3f540e39b476f"
-            ],
-            "index": "pypi",
-            "version": "==1.1.0"
+            "version": "==1.4.5"
         },
         "pytz": {
             "hashes": [
@@ -797,7 +840,7 @@
                 "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
                 "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "markers": "python_version >= '3.7' and python_full_version < '4.0.0'",
             "version": "==2.28.1"
         },
         "requests-toolbelt": {
@@ -820,7 +863,7 @@
                 "sha256:2eb4e6894cde1e017976d2975ac210ef515d7548bc595ba20e195fb9628acdeb",
                 "sha256:63a5c5ce3673d3d5fbbf23cd87e11ab84b6b451436f1b7f19ec54b6bc36ed7ca"
             ],
-            "markers": "python_version < '4.0' and python_full_version >= '3.6.3'",
+            "markers": "python_full_version >= '3.6.3' and python_full_version < '4.0.0'",
             "version": "==12.5.1"
         },
         "secretstorage": {
@@ -859,7 +902,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version < '3.11'",
+            "markers": "python_full_version < '3.11.0a7'",
             "version": "==2.0.1"
         },
         "tomlkit": {
@@ -867,16 +910,24 @@
                 "sha256:25d4e2e446c453be6360c67ddfb88838cfc42026322770ba13d1fbd403a93a5c",
                 "sha256:3235a9010fae54323e727c3ac06fb720752fe6635b3426e379daec60fbd44a83"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "markers": "python_version >= '3.6' and python_full_version < '4.0.0'",
             "version": "==0.11.4"
+        },
+        "tox": {
+            "hashes": [
+                "sha256:445fb1fe5d0b0e8ea59a66c7d03e4b829e3524e61d5905cf3387b56161484eb8",
+                "sha256:78efc716e760390b5129bdf4f46662ff771d767085377f2d623894096f5320ea"
+            ],
+            "index": "pypi",
+            "version": "==4.0.0b2"
         },
         "traitlets": {
             "hashes": [
-                "sha256:0bb9f1f9f017aa8ec187d8b1b2a7a6626a2a1d877116baba52a129bfa124f8e2",
-                "sha256:65fa18961659635933100db8ca120ef6220555286949774b9cfc106f941d1c7a"
+                "sha256:3f2c4e435e271592fe4390f1746ea56836e3a080f84e7833f0f801d9613fec39",
+                "sha256:93663cc8236093d48150e2af5e2ed30fc7904a11a6195e21bab0408af4e6d6c8"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.3.0"
+            "version": "==5.4.0"
         },
         "twine": {
             "hashes": [
@@ -922,8 +973,16 @@
                 "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
                 "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_full_version < '4.0.0'",
             "version": "==1.26.12"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:227ea1b9994fdc5ea31977ba3383ef296d7472ea85be9d6732e42a91c04e80da",
+                "sha256:d07dfc5df5e4e0dbc92862350ad87a36ed505b978f6c39609dc489eadd5b0d27"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==20.16.5"
         },
         "wcwidth": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fc6e1a4c637388e2baddfe36c88dc0d143f8a6c946f6f379980a7ebae46ea5da"
+            "sha256": "acc68fb69bbe765581ecb7b5eb6909faaf58b36ab84d99842aedea1521d38d5d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -107,7 +107,7 @@
                 "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
                 "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
             ],
-            "markers": "python_version >= '3.7'",
+            "index": "pypi",
             "version": "==4.3.0"
         }
     },
@@ -205,11 +205,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:43dadad18a7f168740e66944e4fa82c6611848ff9056ad910f8f7a3e46ab89e0",
-                "sha256:cffdcd380919da6137f76633531a5817e3a9f268575c128249fb637e4f9e73fb"
+                "sha256:36973885b9542e6bd01dea287b2b4b3b21236307c56324fcc3f1160f2d655ed5",
+                "sha256:e232343de1ab72c2aa521b625c80f699e356830fd0e2c620b465b304b17b0516"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.6.15.1"
+            "version": "==2022.9.14"
         },
         "cffi": {
             "hashes": [
@@ -463,11 +463,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
-                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.3"
+            "version": "==3.4"
         },
         "importlib-metadata": {
             "hashes": [
@@ -965,7 +965,7 @@
                 "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
                 "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
             ],
-            "markers": "python_version >= '3.7'",
+            "index": "pypi",
             "version": "==4.3.0"
         },
         "urllib3": {

--- a/liquid_babel/__init__.py
+++ b/liquid_babel/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa
 # pylint: disable=useless-import-alias,missing-module-docstring
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/liquid_babel/filters/__init__.py
+++ b/liquid_babel/filters/__init__.py
@@ -1,8 +1,44 @@
 # flake8: noqa
 # pylint: disable=useless-import-alias,missing-module-docstring
+
+from gettext import NullTranslations
+from typing import Optional
+
+from liquid import Environment
+from liquid_babel.messages.translations import Translations
+
 from .currency import Currency as Currency
 from .date_and_time import DateTime as DateTime
 from .number import Number as Number
+from .translate import Translate
+from .translate import GetText
+from .translate import NGetText
+from .translate import PGetText
+from .translate import NPGetText
+
+
+__all__ = [
+    "Currency",
+    "DateTime",
+    "Number",
+    "Translate",
+    "GetText",
+    "NGetText",
+    "PGetText",
+    "NPGetText",
+    "currency",
+    "number",
+    "money",
+    "money_with_currency",
+    "money_without_currency",
+    "money_without_trailing_zeros",
+    "t",
+    "gettext",
+    "ngettext",
+    "pgettext",
+    "npgettext",
+    "register_translation_filters",
+]
 
 # For convenience. Use defaults.
 currency = Currency()
@@ -17,14 +53,63 @@ money_without_trailing_zeros = Currency(
     currency_digits=False,
 )
 
-__all__ = [
-    "Currency",
-    "DateTime",
-    "Number",
-    "currency",
-    "number",
-    "money",
-    "money_with_currency",
-    "money_without_currency",
-    "money_without_trailing_zeros",
-]
+# For convenience. Translation filters with default options.
+t = Translate()
+gettext = GetText()
+ngettext = NGetText()
+pgettext = PGetText()
+npgettext = NPGetText()
+
+
+def register_translation_filters(
+    env: Environment,
+    replace: bool = False,
+    *,
+    translations_var: str = "translations",
+    default_translations: Optional[Translations] = None,
+    message_interpolation: bool = True,
+    autoescape_message: bool = False,
+) -> None:
+    """Add gettext-style translation filters to a Liquid environment.
+
+    :param env: The liquid.Environment to add translation filters to.
+    :type env: liquid.Environment.
+    :param replace: If True, existing filters with conflicting names will
+        be replaced. Defaults to False.
+    :type replace: bool
+    :param translations_var: The name of a render context variable that
+        resolves to a gettext ``Translations`` class. Defaults to
+        ``"translations"``.
+    :type translations_var: str
+    :param default_translations: A fallback translations class to use if
+        ``translations_var`` can not be resolves. Defaults to
+        ``NullTranslations``.
+    :type default_translations: NullTranslations
+    :param message_interpolation: If ``True`` (default), perform printf-style
+        string interpolation on the translated message, using keyword arguments
+        passed to the filter function.
+    :type message_interpolation: bool
+    :param autoescape_message: If `True` and the current environment has
+        ``autoescape`` set to ``True``, the filter's left value will be escaped
+        before translation. Defaults to ``False``.
+    :type autoescape_message: bool
+    """
+    default_translations = default_translations or NullTranslations()
+    default_filters = (
+        Translate,
+        GetText,
+        NGetText,
+        PGetText,
+        NPGetText,
+    )
+    for _filter in default_filters:
+        if replace or _filter.name not in env.filters:
+            env.add_filter(
+                _filter.name,
+                _filter(  # type: ignore
+                    translations_var=translations_var,
+                    default_translations=default_translations,
+                    message_interpolation=message_interpolation,
+                    autoescape_message=autoescape_message,
+                ),
+            )

--- a/liquid_babel/filters/translate.py
+++ b/liquid_babel/filters/translate.py
@@ -1,6 +1,4 @@
 """A translation filter."""
-import sys
-
 from gettext import NullTranslations
 
 from typing import Any
@@ -26,11 +24,11 @@ from liquid.expression import StringLiteral
 from liquid.filter import string_filter
 from liquid.filter import int_arg
 
-from liquid_babel.messages.extract import MessageText
-from liquid_babel.messages.extract import TranslatableFilter
+from liquid_babel.messages.translations import MessageText
+from liquid_babel.messages.translations import TranslatableFilter
 from liquid_babel.messages.translations import Translations
 
-PGETTEXT_AVAILABLE = sys.version_info[1] >= 3 and sys.version_info[1] > 8
+PGETTEXT_AVAILABLE = hasattr(NullTranslations, "pgettext")
 
 
 # pylint: disable=too-few-public-methods
@@ -48,7 +46,7 @@ class Translate(TranslatableFilter):
         ``translations_var`` can not be resolves. Defaults to
         ``NullTranslations``.
     :type default_translations: NullTranslations
-    :param message_interpolation: If ``True`` (default), perform sprintf-style
+    :param message_interpolation: If ``True`` (default), perform printf-style
         string interpolation on the translated message, using keyword arguments
         passed to the filter function.
     :type message_interpolation: bool

--- a/liquid_babel/filters/translate.py
+++ b/liquid_babel/filters/translate.py
@@ -30,8 +30,6 @@ from liquid_babel.messages.translations import TranslatableFilter
 from liquid_babel.messages.translations import Translations
 from liquid_babel.messages.translations import to_liquid_string
 
-PGETTEXT_AVAILABLE = hasattr(NullTranslations, "pgettext")
-
 __all__ = [
     "Translate",
     "GetText",
@@ -149,7 +147,7 @@ class Translate(BaseTranslateFilter, TranslatableFilter):
                 autoescape=auto_escape and self.autoescape_message,
             )
 
-            if PGETTEXT_AVAILABLE and message_context is not None:
+            if message_context is not None:
                 text = translations.npgettext(
                     str(message_context),
                     __left,
@@ -159,7 +157,7 @@ class Translate(BaseTranslateFilter, TranslatableFilter):
             else:
                 text = translations.ngettext(__left, plural, n)
         else:
-            if PGETTEXT_AVAILABLE and message_context is not None:
+            if message_context is not None:
                 text = translations.pgettext(
                     str(message_context),
                     __left,

--- a/liquid_babel/filters/translate.py
+++ b/liquid_babel/filters/translate.py
@@ -38,7 +38,25 @@ __all__ = [
 
 
 class BaseTranslateFilter(ABC):
-    """Base class for the default translation filters."""
+    """Base class for the default translation filters.
+
+    :param translations_var: The name of a render context variable that
+        resolves to a gettext ``Translations`` class. Defaults to
+        ``"translations"``.
+    :type translations_var: str
+    :param default_translations: A fallback translations class to use if
+        ``translations_var`` can not be resolves. Defaults to
+        ``NullTranslations``.
+    :type default_translations: NullTranslations
+    :param message_interpolation: If ``True`` (default), perform printf-style
+        string interpolation on the translated message, using keyword arguments
+        passed to the filter function.
+    :type message_interpolation: bool
+    :param autoescape_message: If `True` and the current environment has
+        ``autoescape`` set to ``True``, the filter's left value will be escaped
+        before translation. Defaults to ``False``.
+    :type autoescape_message: bool
+    """
 
     name = "base"
     re_vars = re.compile(r"(?<!%)%\((\w+)\)s")
@@ -95,23 +113,6 @@ class Translate(BaseTranslateFilter, TranslatableFilter):
 
     Depending on the keyword arguments provided when the resulting filter
     is called, it could behave like gettext, ngettext, pgettext or npgettext.
-
-    :param translations_var: The name of a render context variable that
-        resolves to a gettext ``Translations`` class. Defaults to
-        ``"translations"``.
-    :type translations_var: str
-    :param default_translations: A fallback translations class to use if
-        ``translations_var`` can not be resolves. Defaults to
-        ``NullTranslations``.
-    :type default_translations: NullTranslations
-    :param message_interpolation: If ``True`` (default), perform printf-style
-        string interpolation on the translated message, using keyword arguments
-        passed to the filter function.
-    :type message_interpolation: bool
-    :param autoescape_message: If `True` and the current environment has
-        ``autoescape`` set to ``True``, the filter's left value will be escaped
-        before translation. Defaults to ``False``.
-    :type autoescape_message: bool
     """
 
     name = "t"
@@ -196,6 +197,10 @@ class Translate(BaseTranslateFilter, TranslatableFilter):
             else:
                 funcname = "ngettext"
                 message = (left.value, plural.value)
+        elif plural is not None:
+            # Don't attempt to extract any messages if plural is given
+            # but not a string literal
+            return None
         else:
             if isinstance(_context, StringLiteral):
                 funcname = "pgettext"

--- a/liquid_babel/filters/translate.py
+++ b/liquid_babel/filters/translate.py
@@ -16,13 +16,7 @@ from typing import Union
 
 from liquid import Context
 from liquid import Environment
-from liquid import escape
 from liquid import Markup
-
-try:
-    from liquid import soft_str  # type: ignore
-except ImportError:  # pragma: no cover
-    soft_str = str  # pylint: disable=invalid-name
 
 from liquid.expression import Expression
 from liquid.expression import Filter
@@ -34,6 +28,7 @@ from liquid.filter import int_arg
 from liquid_babel.messages.translations import MessageText
 from liquid_babel.messages.translations import TranslatableFilter
 from liquid_babel.messages.translations import Translations
+from liquid_babel.messages.translations import to_liquid_string
 
 PGETTEXT_AVAILABLE = hasattr(NullTranslations, "pgettext")
 
@@ -83,7 +78,7 @@ class BaseTranslateFilter(ABC):
         """Return the message string formatted with the given message variables."""
         with context.extend(namespace=message_vars):
             _vars = {
-                k: self._to_liquid_string(context.resolve(k), context.env.autoescape)
+                k: to_liquid_string(context.resolve(k), context.env.autoescape)
                 for k in self.re_vars.findall(message_text)
             }
 
@@ -97,29 +92,6 @@ class BaseTranslateFilter(ABC):
             Translations,
             context.resolve(self.translations_var, self.default_translations),
         )
-
-    def _to_liquid_string(self, val: Any, autoescape: bool) -> str:
-        if isinstance(val, str) or (autoescape and hasattr(val, "__html__")):
-            pass
-        elif isinstance(val, bool):
-            val = str(val).lower()
-        elif val is None:
-            val = ""
-        elif isinstance(val, list):
-            if autoescape:
-                val = Markup("").join(soft_str(itm) for itm in val)
-            else:
-                val = "".join(soft_str(itm) for itm in val)
-        elif isinstance(val, range):
-            val = f"{val.start}..{val.stop - 1}"
-        else:
-            val = str(val)
-
-        if autoescape:
-            val = escape(val)
-
-        assert isinstance(val, str)
-        return val
 
 
 # pylint: disable=too-few-public-methods
@@ -159,7 +131,7 @@ class Translate(BaseTranslateFilter, TranslatableFilter):
         **kwargs: Any,
     ) -> str:
         auto_escape = context.env.autoescape
-        __left = self._to_liquid_string(
+        __left = to_liquid_string(
             __left,
             autoescape=auto_escape and self.autoescape_message,
         )
@@ -172,7 +144,7 @@ class Translate(BaseTranslateFilter, TranslatableFilter):
         n = _count(kwargs.get("count"))
 
         if plural is not None and n is not None:
-            plural = self._to_liquid_string(
+            plural = to_liquid_string(
                 plural,
                 autoescape=auto_escape and self.autoescape_message,
             )
@@ -254,7 +226,7 @@ class GetText(BaseTranslateFilter, TranslatableFilter):
         **kwargs: Any,
     ) -> str:
         auto_escape = context.env.autoescape
-        __left = self._to_liquid_string(
+        __left = to_liquid_string(
             __left,
             autoescape=auto_escape and self.autoescape_message,
         )
@@ -302,12 +274,12 @@ class NGetText(GetText):
         **kwargs: Any,
     ) -> str:
         auto_escape = context.env.autoescape
-        __left = self._to_liquid_string(
+        __left = to_liquid_string(
             __left,
             autoescape=auto_escape and self.autoescape_message,
         )
 
-        __plural = self._to_liquid_string(
+        __plural = to_liquid_string(
             __plural,
             autoescape=auto_escape and self.autoescape_message,
         )
@@ -361,12 +333,12 @@ class PGetText(BaseTranslateFilter, TranslatableFilter):
         **kwargs: Any,
     ) -> str:
         auto_escape = context.env.autoescape
-        __left = self._to_liquid_string(
+        __left = to_liquid_string(
             __left,
             autoescape=auto_escape and self.autoescape_message,
         )
 
-        __message_context = self._to_liquid_string(
+        __message_context = to_liquid_string(
             __message_context,
             autoescape=auto_escape and self.autoescape_message,
         )
@@ -417,17 +389,17 @@ class NPGetText(BaseTranslateFilter, TranslatableFilter):
         **kwargs: Any,
     ) -> str:
         auto_escape = context.env.autoescape
-        __left = self._to_liquid_string(
+        __left = to_liquid_string(
             __left,
             autoescape=auto_escape and self.autoescape_message,
         )
 
-        __message_context = self._to_liquid_string(
+        __message_context = to_liquid_string(
             __message_context,
             autoescape=auto_escape and self.autoescape_message,
         )
 
-        __plural = self._to_liquid_string(
+        __plural = to_liquid_string(
             __plural,
             autoescape=auto_escape and self.autoescape_message,
         )

--- a/liquid_babel/filters/translate.py
+++ b/liquid_babel/filters/translate.py
@@ -98,7 +98,7 @@ class BaseTranslateFilter(ABC):
             context.resolve(self.translations_var, self.default_translations),
         )
 
-    def _to_liquid_string(self, val: object, autoescape: bool) -> str:
+    def _to_liquid_string(self, val: Any, autoescape: bool) -> str:
         if isinstance(val, str) or (autoescape and hasattr(val, "__html__")):
             pass
         elif isinstance(val, bool):

--- a/liquid_babel/filters/translate.py
+++ b/liquid_babel/filters/translate.py
@@ -166,7 +166,11 @@ class Translate(TranslatableFilter):
 
         if isinstance(_context, StringLiteral):
             funcname = "pgettext" if len(message) == 1 else "npgettext"
-            message = (_context.value,) + message
+            return MessageText(
+                lineno=lineno,
+                funcname=funcname,
+                message=((_context.value, "c"),) + message,
+            )
 
         return MessageText(
             lineno=lineno,
@@ -329,7 +333,7 @@ class PGetText(Translate):
         return MessageText(
             lineno=lineno,
             funcname=self.name,
-            message=(ctx.value, left.value),
+            message=((ctx.value, "c"), left.value),
         )
 
 
@@ -392,7 +396,7 @@ class NPGetText(Translate):
         return MessageText(
             lineno=lineno,
             funcname=self.name,
-            message=(ctx.value, left.value, plural.value),
+            message=((ctx.value, "c"), left.value, plural.value),
         )
 
 

--- a/liquid_babel/filters/translate.py
+++ b/liquid_babel/filters/translate.py
@@ -133,11 +133,9 @@ class Translate(BaseTranslateFilter, TranslatableFilter):
             __left,
             autoescape=auto_escape and self.autoescape_message,
         )
+
         translations = self._resolve_translations(context)
 
-        # With Python 3.7, where pgettext is not available, the "context"
-        # argument will be ignored.
-        message_context = __message_context or None
         plural = kwargs.pop("plural", None)
         n = _count(kwargs.get("count"))
 
@@ -147,9 +145,12 @@ class Translate(BaseTranslateFilter, TranslatableFilter):
                 autoescape=auto_escape and self.autoescape_message,
             )
 
-            if message_context is not None:
+            if __message_context is not None:
                 text = translations.npgettext(
-                    str(message_context),
+                    to_liquid_string(
+                        __message_context,
+                        autoescape=auto_escape and self.autoescape_message,
+                    ),
                     __left,
                     plural,
                     n,
@@ -157,9 +158,12 @@ class Translate(BaseTranslateFilter, TranslatableFilter):
             else:
                 text = translations.ngettext(__left, plural, n)
         else:
-            if message_context is not None:
+            if __message_context is not None:
                 text = translations.pgettext(
-                    str(message_context),
+                    to_liquid_string(
+                        __message_context,
+                        autoescape=auto_escape and self.autoescape_message,
+                    ),
                     __left,
                 )
 

--- a/liquid_babel/filters/translate.py
+++ b/liquid_babel/filters/translate.py
@@ -261,6 +261,7 @@ class NGetText(GetText):
             text = Markup(text)
 
         if self.message_interpolation:
+            # TODO: try
             text = text % kwargs
 
         return text

--- a/liquid_babel/filters/translate.py
+++ b/liquid_babel/filters/translate.py
@@ -1,0 +1,121 @@
+"""A translation filter."""
+import sys
+
+from gettext import NullTranslations
+
+from typing import Any
+from typing import cast
+from typing import Type
+from typing import Union
+
+from liquid import Context
+
+from liquid.filter import string_filter
+from liquid.filter import with_context
+
+from markupsafe import escape
+from markupsafe import Markup
+
+
+PGETTEXT_AVAILABLE = sys.version_info[1] >= 3 and sys.version_info[1] > 8
+
+
+# pylint: disable=too-few-public-methods
+@with_context
+class Translate:
+    """A Liquid filter for translating string to other languages.
+
+    :param translations_var: The name of a render context variable that
+        resolves to a gettext ``Translations`` class. Defaults to
+        ``"translations"``.
+    :type translations_var: str
+    :param default_translations: A fallback translations class to use if
+        ``translations_var`` can not be resolves. Defaults to
+        ``NullTranslations``.
+    :type default_translations: NullTranslations
+    :param c_style_interpolation: If ``True`` (default), perform c-style
+        string interpolation on the translated message, using keyword arguments
+        passed to the filter function.
+    :type c_style_interpolation: bool
+    :param autoescape_message: If `True` and the current environment has
+        ``autoescape`` set to ``True``, the filter's left value will be escaped
+        before translation. Defaults to ``False``.
+    :type autoescape_message: bool
+    """
+
+    def __init__(
+        self,
+        *,
+        translations_var: str = "translations",
+        default_translations: Type[NullTranslations] = NullTranslations,
+        c_style_interpolation: bool = True,
+        autoescape_message: bool = False,
+    ) -> None:
+        self.translations_var = translations_var
+        self.default_translations = default_translations
+        self.c_style_interpolation = c_style_interpolation
+        self.autoescape_message = autoescape_message
+
+    @string_filter
+    def __call__(
+        self,
+        left: str,
+        *,
+        context: Context,
+        **kwargs: Any,
+    ) -> str:
+        auto_escape = context.env.autoescape
+
+        message_context = kwargs.pop("context", None)
+        plural = kwargs.pop("plural", None)
+        n = _count(kwargs.get("count"))
+
+        if auto_escape and self.autoescape_message:
+            left = escape(left)
+            if plural is not None:
+                plural = escape(plural)
+
+        translations = cast(
+            NullTranslations,
+            context.resolve(
+                self.translations_var,
+                default=self.default_translations,
+            ),
+        )
+
+        if plural is not None and n is not None:
+            if PGETTEXT_AVAILABLE and message_context is not None:
+                text = translations.npgettext(
+                    str(message_context),
+                    left,
+                    plural,
+                    n,
+                )
+            else:
+                text = translations.ngettext(left, plural, n)
+        else:
+            if PGETTEXT_AVAILABLE and message_context is not None:
+                text = translations.pgettext(
+                    str(message_context),
+                    left,
+                )
+
+            else:
+                text = translations.gettext(left)
+
+        if auto_escape:
+            text = Markup(text)
+
+        if self.c_style_interpolation:
+            text = text % kwargs
+
+        return text
+
+
+def _count(val: Any) -> Union[int, None]:
+    if val in (None, False, True):
+        return None
+    try:
+        return int(val)
+    except ValueError:
+        return None

--- a/liquid_babel/messages/__init__.py
+++ b/liquid_babel/messages/__init__.py
@@ -1,0 +1,10 @@
+"""Liquid Babel message extraction and translation."""
+from .extract import extract_liquid
+from .extract import extract_from_template
+from .extract import extract_from_templates
+
+__all__ = (
+    "extract_liquid",
+    "extract_from_template",
+    "extract_from_templates",
+)

--- a/liquid_babel/messages/exceptions.py
+++ b/liquid_babel/messages/exceptions.py
@@ -1,9 +1,14 @@
 """Liquid translation exceptions."""
 from liquid.exceptions import Error
+from liquid.exceptions import LiquidSyntaxError
 
 
 class TranslationError(Error):
     """Base exception for translation errors."""
+
+
+class TranslationSyntaxError(LiquidSyntaxError):
+    """Exception raised when a syntax error is found within a translation block."""
 
 
 class TranslationValueError(TranslationError):

--- a/liquid_babel/messages/exceptions.py
+++ b/liquid_babel/messages/exceptions.py
@@ -1,0 +1,14 @@
+"""Liquid translation exceptions."""
+from liquid.exceptions import Error
+
+
+class TranslationError(Error):
+    """Base exception for translation errors."""
+
+
+class TranslationValueError(TranslationError):
+    """Exception raised when translation message interpolation fails with a ValueError."""
+
+
+class TranslationKeyError(TranslationError):
+    """Exception raised when translation message interpolation fails with a KeyError."""

--- a/liquid_babel/messages/extract.py
+++ b/liquid_babel/messages/extract.py
@@ -1,0 +1,56 @@
+"""Extract localization messages from Liquid templates."""
+from typing import Any
+from typing import Dict
+from typing import Iterator
+from typing import List
+from typing import NamedTuple
+from typing import Optional
+from typing import TextIO
+
+
+from liquid import Template
+from liquid.template import BoundTemplate
+
+
+class MessageTuple(NamedTuple):
+    """The tuple expected to be returned from babel extraction methods."""
+
+    lineno: int
+    funcname: str
+    message: str
+    comments: List[str]
+
+
+def extract_liquid(
+    fileobj: TextIO,
+    keywords: List[str],
+    _: Optional[List[str]] = None,
+    options: Optional[Dict[str, Any]] = None,
+) -> Iterator[MessageTuple]:
+    """A babel compatible extraction method for Python Liquid templates.
+
+    See https://babel.pocoo.org/en/latest/messages.html
+
+    Keywords are the names of Liquid filters operating on translatable
+    strings. Any Liquid.ast.Node class that defines a `messages` method
+    will also be recognized as containing translatable strings.
+
+    Comment tags are currently ignored as it is assumed that a translatable
+    Liquid tag or filter knows how to find its own comments.
+
+    Options are arguments passed to the liquid.Template constructor with
+    the contents of `fileobj` as the template's source.
+
+    Use `extract_from_template` to extract messages from an existing
+    template bound to an existing environment.
+    """
+    template = Template(fileobj.read(), **options or {})
+    return extract_from_template(template=template, keywords=keywords)
+
+
+def extract_from_template(
+    template: BoundTemplate,
+    keywords: List[str],
+) -> Iterator[MessageTuple]:
+    """"""
+    # TODO:

--- a/liquid_babel/messages/extract.py
+++ b/liquid_babel/messages/extract.py
@@ -55,7 +55,12 @@ class TranslatableFilter(ABC):  # pylint: disable=too-few-public-methods
     """Base class for translatable filters."""
 
     @abstractmethod
-    def message(self, _filter: Filter, lineno: int) -> Optional[MessageText]:
+    def message(
+        self,
+        left: Expression,
+        _filter: Filter,
+        lineno: int,
+    ) -> Optional[MessageText]:
         """Generate a sequence of translation messages."""
 
 
@@ -106,7 +111,11 @@ def extract_from_template(
     def visit_expression(expr: Expression, lineno: int) -> Iterator[MessageTuple]:
         if isinstance(expr, FilteredExpression):
             for _lineno, funcname, message in _extract_from_filters(
-                template.env, expr.filters, lineno, keywords
+                template.env,
+                expr.expression,
+                expr.filters,
+                lineno,
+                keywords,
             ):
                 if _comments and _comments[-1][0] < lineno - 1:
                     _comments.clear()
@@ -164,6 +173,7 @@ def extract_from_template(
 
 def _extract_from_filters(
     environment: Environment,
+    expression: Expression,
     filters: List[Filter],
     lineno: int,
     keywords: List[str],
@@ -172,4 +182,4 @@ def _extract_from_filters(
     for _filter in filters:
         filter_func = environment.filters.get(_filter.name)
         if _filter.name in keywords and isinstance(filter_func, TranslatableFilter):
-            yield filter_func.message(_filter, lineno)  # type: ignore
+            yield filter_func.message(expression, _filter, lineno)  # type: ignore

--- a/liquid_babel/messages/extract.py
+++ b/liquid_babel/messages/extract.py
@@ -1,17 +1,11 @@
 """Extract localization messages from Liquid templates."""
-from abc import ABC
-from abc import abstractmethod
-
 from typing import Any
 from typing import Dict
-from typing import Iterable
 from typing import Iterator
 from typing import List
-from typing import NamedTuple
 from typing import Optional
 from typing import TextIO
 from typing import Tuple
-from typing import Union
 
 from liquid import Environment
 from liquid import Template
@@ -26,42 +20,10 @@ from liquid.token import TOKEN_TAG
 from liquid.builtin.tags.comment_tag import CommentNode
 
 
-class MessageTuple(NamedTuple):
-    """The tuple expected to be returned from babel extraction methods."""
-
-    lineno: int
-    funcname: str
-    message: Union[str, Tuple[str, ...]]
-    comments: List[str]
-
-
-class MessageText(NamedTuple):
-    """Partial message tuple returned from translatable tags."""
-
-    lineno: int
-    funcname: str
-    message: Tuple[str, ...]
-
-
-class TranslatableTag(ABC):  # pylint: disable=too-few-public-methods
-    """Base class for translatable tags."""
-
-    @abstractmethod
-    def messages(self) -> Iterable[MessageText]:
-        """Generate a sequence of translation messages."""
-
-
-class TranslatableFilter(ABC):  # pylint: disable=too-few-public-methods
-    """Base class for translatable filters."""
-
-    @abstractmethod
-    def message(
-        self,
-        left: Expression,
-        _filter: Filter,
-        lineno: int,
-    ) -> Optional[MessageText]:
-        """Generate a sequence of translation messages."""
+from .translations import MessageText
+from .translations import MessageTuple
+from .translations import TranslatableFilter
+from .translations import TranslatableTag
 
 
 def extract_liquid(

--- a/liquid_babel/messages/extract.py
+++ b/liquid_babel/messages/extract.py
@@ -9,7 +9,6 @@ from typing import Tuple
 from typing import Union
 
 from liquid import Environment
-from liquid import Template
 from liquid.ast import Node
 
 from liquid.expression import Expression
@@ -55,9 +54,10 @@ def extract_liquid(
     to extract messages from an existing template bound to an existing
     environment.
     """
-    template = Template(fileobj.read(), **options or {})
-    register_translation_filters(template.env, replace=False)
-    _register_translation_tag(template.env, keywords)
+    env = Environment(**options or {})
+    register_translation_filters(env, replace=False)
+    env.add_tag(TranslateTag)
+    template = env.from_string(fileobj.read())
     return extract_from_template(
         template=template,
         keywords=keywords,
@@ -151,10 +151,3 @@ def _extract_from_filters(
             message = filter_func.message(expression, _filter, lineno)  # type: ignore
             if message:
                 yield message
-
-
-def _register_translation_tag(env: Environment, keywords: List[str]) -> None:
-    for funcname in keywords:
-        if isinstance(env.tags.get(funcname), TranslatableTag):
-            return
-    env.add_tag(TranslateTag)

--- a/liquid_babel/messages/extract.py
+++ b/liquid_babel/messages/extract.py
@@ -101,6 +101,7 @@ def extract_from_template(
         if isinstance(node, CommentNode) and node.text is not None:
             comment_text = node.text.strip()
             for comment_tag in _comment_tags:
+                # TODO: strip comment tag from message comment?
                 if comment_text.startswith(comment_tag):
                     # Our multi-line comments are wrapped in a tag, so we're
                     # only ever going to have one comment text object to deal
@@ -147,4 +148,6 @@ def _extract_from_filters(
     for _filter in filters:
         filter_func = environment.filters.get(_filter.name)
         if _filter.name in keywords and isinstance(filter_func, TranslatableFilter):
-            yield filter_func.message(expression, _filter, lineno)  # type: ignore
+            message = filter_func.message(expression, _filter, lineno)  # type: ignore
+            if message:
+                yield message

--- a/liquid_babel/messages/extract.py
+++ b/liquid_babel/messages/extract.py
@@ -1,15 +1,29 @@
 """Extract localization messages from Liquid templates."""
+from abc import ABC
+from abc import abstractmethod
+
 from typing import Any
 from typing import Dict
+from typing import Iterable
 from typing import Iterator
 from typing import List
 from typing import NamedTuple
 from typing import Optional
 from typing import TextIO
+from typing import Tuple
+from typing import Union
 
-
+from liquid import Environment
 from liquid import Template
+from liquid.ast import Node
+
+from liquid.expression import Expression
+from liquid.expression import Filter
+from liquid.expression import FilteredExpression
+
 from liquid.template import BoundTemplate
+from liquid.token import TOKEN_TAG
+from liquid.builtin.tags.comment_tag import CommentNode
 
 
 class MessageTuple(NamedTuple):
@@ -17,40 +31,145 @@ class MessageTuple(NamedTuple):
 
     lineno: int
     funcname: str
-    message: str
+    message: Union[str, Tuple[str, ...]]
     comments: List[str]
+
+
+class MessageText(NamedTuple):
+    """Partial message tuple returned from translatable tags."""
+
+    lineno: int
+    funcname: str
+    message: Tuple[str, ...]
+
+
+class TranslatableTag(ABC):  # pylint: disable=too-few-public-methods
+    """Base class for translatable tags."""
+
+    @abstractmethod
+    def messages(self) -> Iterable[MessageText]:
+        """Generate a sequence of translation messages."""
+
+
+class TranslatableFilter(ABC):  # pylint: disable=too-few-public-methods
+    """Base class for translatable filters."""
+
+    @abstractmethod
+    def message(self, _filter: Filter, lineno: int) -> Optional[MessageText]:
+        """Generate a sequence of translation messages."""
 
 
 def extract_liquid(
     fileobj: TextIO,
     keywords: List[str],
-    _: Optional[List[str]] = None,
+    comment_tags: Optional[List[str]] = None,
     options: Optional[Dict[str, Any]] = None,
 ) -> Iterator[MessageTuple]:
     """A babel compatible extraction method for Python Liquid templates.
 
     See https://babel.pocoo.org/en/latest/messages.html
 
-    Keywords are the names of Liquid filters operating on translatable
-    strings. Any Liquid.ast.Node class that defines a `messages` method
-    will also be recognized as containing translatable strings.
+    Keywords are the names of Liquid filters or tags operating on translatable
+    strings. For a filter to contribute to message extraction, it must also
+    appear as a child of a `FilteredExpression` and be a `TranslatableFilter`.
+    Similarly, tags must produce a node that is a `TranslatableTag`.
 
-    Comment tags are currently ignored as it is assumed that a translatable
-    Liquid tag or filter knows how to find its own comments.
+    Where a Liquid comment contains a prefix in `comment_tags`, the comment
+    will be attached to the translatable filter or tag immediately following
+    the comment. Python Liquid's non-standard shorthand comments are not
+    supported.
 
-    Options are arguments passed to the liquid.Template constructor with
-    the contents of `fileobj` as the template's source.
-
-    Use `extract_from_template` to extract messages from an existing
-    template bound to an existing environment.
+    Options are arguments passed to the `liquid.Template` constructor with the
+    contents of `fileobj` as the template's source. Use `extract_from_template`
+    to extract messages from an existing template bound to an existing
+    environment.
     """
     template = Template(fileobj.read(), **options or {})
-    return extract_from_template(template=template, keywords=keywords)
+    # TODO: register default translation filter funcs
+    return extract_from_template(
+        template=template,
+        keywords=keywords,
+        comment_tags=comment_tags,
+    )
 
 
 def extract_from_template(
     template: BoundTemplate,
     keywords: List[str],
+    comment_tags: Optional[List[str]] = None,
 ) -> Iterator[MessageTuple]:
     """"""
-    # TODO:
+
+    _comment_tags = comment_tags or []
+    _comments: List[Tuple[int, str]] = []
+
+    def visit_expression(expr: Expression, lineno: int) -> Iterator[MessageTuple]:
+        if isinstance(expr, FilteredExpression):
+            for _lineno, funcname, message in _extract_from_filters(
+                template.env, expr.filters, lineno, keywords
+            ):
+                if _comments and _comments[-1][0] < lineno - 1:
+                    _comments.clear()
+
+                yield MessageTuple(
+                    lineno=_lineno,
+                    funcname=funcname,
+                    message=message,
+                    comments=[text for _, text in _comments],
+                )
+                _comments.clear()
+
+        for expression in expr.children():
+            yield from visit_expression(expression, lineno)
+
+    def visit(node: Node) -> Iterator[MessageTuple]:
+        token = node.token()
+        if isinstance(node, CommentNode) and node.text is not None:
+            comment_text = node.text.strip()
+            for comment_tag in _comment_tags:
+                if comment_text.startswith(comment_tag):
+                    # Our multi-line comments are wrapped in a tag, so we're
+                    # only ever going to have one comment text object to deal
+                    # with.
+                    _comments.clear()
+                    _comments.append((node.tok.linenum, comment_text))
+                    break
+        elif (
+            token.type == TOKEN_TAG
+            and token.value in keywords
+            and isinstance(node, TranslatableTag)
+        ):
+
+            for lineno, funcname, message in node.messages():
+                if _comments and _comments[-1][0] < lineno - 1:
+                    _comments.clear()
+
+                yield MessageTuple(
+                    lineno=lineno,
+                    funcname=funcname,
+                    message=message,
+                    comments=[text for _, text in _comments],
+                )
+                _comments.clear()
+
+        for child in node.children():
+            if child.expression:
+                yield from visit_expression(child.expression, token.linenum)
+            if child.node:
+                yield from visit(child.node)
+
+    for node in template.tree.statements:
+        yield from visit(node)
+
+
+def _extract_from_filters(
+    environment: Environment,
+    filters: List[Filter],
+    lineno: int,
+    keywords: List[str],
+) -> Iterator[MessageText]:
+    """"""
+    for _filter in filters:
+        filter_func = environment.filters.get(_filter.name)
+        if _filter.name in keywords and isinstance(filter_func, TranslatableFilter):
+            yield filter_func.message(_filter, lineno)  # type: ignore

--- a/liquid_babel/messages/extract.py
+++ b/liquid_babel/messages/extract.py
@@ -157,4 +157,4 @@ def _register_translation_tag(env: Environment, keywords: List[str]) -> None:
     for funcname in keywords:
         if isinstance(env.tags.get(funcname), TranslatableTag):
             return
-    env.add_filter("trans", TranslateTag)
+    env.add_tag(TranslateTag)

--- a/liquid_babel/messages/translations.py
+++ b/liquid_babel/messages/translations.py
@@ -33,7 +33,7 @@ class MessageTuple(NamedTuple):
 
     lineno: int
     funcname: str
-    message: Union[str, Tuple[str, ...]]
+    message: Union[str, Tuple[Union[str, Tuple[str, ...]], ...]]
     comments: List[str]
 
 
@@ -42,7 +42,7 @@ class MessageText(NamedTuple):
 
     lineno: int
     funcname: str
-    message: Tuple[str, ...]
+    message: Tuple[Union[str, Tuple[str, ...]], ...]
 
 
 class TranslatableTag(ABC):  # pylint: disable=too-few-public-methods

--- a/liquid_babel/messages/translations.py
+++ b/liquid_babel/messages/translations.py
@@ -1,0 +1,15 @@
+from typing_extensions import Protocol
+
+
+class Translations(Protocol):
+    def gettext(self, message: str) -> str:
+        ...
+
+    def ngettext(self, singular: str, plural: str, n: int) -> str:
+        ...
+
+    def pgettext(self, context: str, message: str) -> str:
+        ...
+
+    def npgettext(self, context: str, singular: str, plural: str, n: int) -> str:
+        ...

--- a/liquid_babel/messages/translations.py
+++ b/liquid_babel/messages/translations.py
@@ -2,6 +2,7 @@
 from abc import ABC
 from abc import abstractmethod
 
+from typing import Any
 from typing import Iterable
 from typing import List
 from typing import NamedTuple
@@ -10,6 +11,14 @@ from typing import Tuple
 from typing import Union
 
 from typing_extensions import Protocol
+
+from liquid import escape
+from liquid import Markup
+
+try:
+    from liquid import soft_str  # type: ignore
+except ImportError:  # pragma: no cover
+    soft_str = str  # pylint: disable=invalid-name
 
 from liquid.expression import Expression
 from liquid.expression import Filter
@@ -83,3 +92,28 @@ class TranslatableFilter(ABC):  # pylint: disable=too-few-public-methods
         lineno: int,
     ) -> Optional[MessageText]:
         """Generate a sequence of translation messages."""
+
+
+def to_liquid_string(val: Any, autoescape: bool) -> str:
+    """Return a Liquid string representation of the given value."""
+    if isinstance(val, str) or (autoescape and hasattr(val, "__html__")):
+        pass
+    elif isinstance(val, bool):
+        val = str(val).lower()
+    elif val is None:
+        val = ""
+    elif isinstance(val, list):
+        if autoescape:
+            val = Markup("").join(soft_str(itm) for itm in val)
+        else:
+            val = "".join(soft_str(itm) for itm in val)
+    elif isinstance(val, range):
+        val = f"{val.start}..{val.stop - 1}"
+    else:
+        val = str(val)
+
+    if autoescape:
+        val = escape(val)
+
+    assert isinstance(val, str)
+    return val

--- a/liquid_babel/messages/translations.py
+++ b/liquid_babel/messages/translations.py
@@ -24,8 +24,6 @@ DEFAULT_KEYWORDS = {
     "npgettext": ((1, "c"), 2, 3),
 }
 
-# pylint: disable=unnecessary-ellipsis
-
 
 class Translations(Protocol):
     """The object expected to be available in a render context for
@@ -38,19 +36,15 @@ class Translations(Protocol):
 
     def gettext(self, message: str) -> str:
         """Lookup the message in the catalog."""
-        ...
 
     def ngettext(self, singular: str, plural: str, n: int) -> str:
         """Do plural-forms message lookup."""
-        ...
 
     def pgettext(self, context: str, message: str) -> str:
         """Lookup the context and message in the catalog."""
-        ...
 
     def npgettext(self, context: str, singular: str, plural: str, n: int) -> str:
         """Do plural-forms context and message lookup."""
-        ...
 
 
 class MessageTuple(NamedTuple):

--- a/liquid_babel/messages/translations.py
+++ b/liquid_babel/messages/translations.py
@@ -33,6 +33,10 @@ DEFAULT_KEYWORDS = {
     "npgettext": ((1, "c"), 2, 3),
 }
 
+DEFAULT_COMMENT_TAGS = [
+    "Translators:",
+]
+
 
 class Translations(Protocol):
     """The object expected to be available in a render context for
@@ -56,12 +60,20 @@ class Translations(Protocol):
         """Do plural-forms context and message lookup."""
 
 
+MESSAGES = Union[
+    str,
+    Tuple[str, ...],
+    Tuple[Tuple[str, str], str],
+    Tuple[Tuple[str, str], str, str],
+]
+
+
 class MessageTuple(NamedTuple):
     """The tuple expected to be returned from babel extraction methods."""
 
     lineno: int
     funcname: str
-    message: Union[str, Tuple[Union[str, Tuple[str, ...]], ...]]
+    message: MESSAGES
     comments: List[str]
 
 
@@ -70,7 +82,7 @@ class MessageText(NamedTuple):
 
     lineno: int
     funcname: str
-    message: Tuple[Union[str, Tuple[str, ...]], ...]
+    message: MESSAGES
 
 
 class TranslatableTag(ABC):  # pylint: disable=too-few-public-methods

--- a/liquid_babel/messages/translations.py
+++ b/liquid_babel/messages/translations.py
@@ -1,3 +1,4 @@
+"""Translation related objects used by filters, tags and extraction functions."""
 from abc import ABC
 from abc import abstractmethod
 
@@ -13,18 +14,42 @@ from typing_extensions import Protocol
 from liquid.expression import Expression
 from liquid.expression import Filter
 
+DEFAULT_KEYWORDS = {
+    "t": None,
+    "trans": None,
+    "translate": None,
+    "gettext": None,
+    "ngettext": (1, 2),
+    "pgettext": ((1, "c"), 2),
+    "npgettext": ((1, "c"), 2, 3),
+}
+
+# pylint: disable=unnecessary-ellipsis
+
 
 class Translations(Protocol):
+    """The object expected to be available in a render context for
+    translating message text.
+
+    Could be a `GNUTranslations` instance from the `gettext` module,
+    a Babel `Translations` object, or any object implementing `gettext`,
+    `ngettext`, `pgettext` and `npgettext` methods.
+    """
+
     def gettext(self, message: str) -> str:
+        """Lookup the message in the catalog."""
         ...
 
     def ngettext(self, singular: str, plural: str, n: int) -> str:
+        """Do plural-forms message lookup."""
         ...
 
     def pgettext(self, context: str, message: str) -> str:
+        """Lookup the context and message in the catalog."""
         ...
 
     def npgettext(self, context: str, singular: str, plural: str, n: int) -> str:
+        """Do plural-forms context and message lookup."""
         ...
 
 

--- a/liquid_babel/messages/translations.py
+++ b/liquid_babel/messages/translations.py
@@ -1,4 +1,17 @@
+from abc import ABC
+from abc import abstractmethod
+
+from typing import Iterable
+from typing import List
+from typing import NamedTuple
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
 from typing_extensions import Protocol
+
+from liquid.expression import Expression
+from liquid.expression import Filter
 
 
 class Translations(Protocol):
@@ -13,3 +26,41 @@ class Translations(Protocol):
 
     def npgettext(self, context: str, singular: str, plural: str, n: int) -> str:
         ...
+
+
+class MessageTuple(NamedTuple):
+    """The tuple expected to be returned from babel extraction methods."""
+
+    lineno: int
+    funcname: str
+    message: Union[str, Tuple[str, ...]]
+    comments: List[str]
+
+
+class MessageText(NamedTuple):
+    """Partial message tuple returned from translatable tags."""
+
+    lineno: int
+    funcname: str
+    message: Tuple[str, ...]
+
+
+class TranslatableTag(ABC):  # pylint: disable=too-few-public-methods
+    """Base class for translatable tags."""
+
+    @abstractmethod
+    def messages(self) -> Iterable[MessageText]:
+        """Generate a sequence of translation messages."""
+
+
+class TranslatableFilter(ABC):  # pylint: disable=too-few-public-methods
+    """Base class for translatable filters."""
+
+    @abstractmethod
+    def message(
+        self,
+        left: Expression,
+        _filter: Filter,
+        lineno: int,
+    ) -> Optional[MessageText]:
+        """Generate a sequence of translation messages."""

--- a/liquid_babel/tags/__init__.py
+++ b/liquid_babel/tags/__init__.py
@@ -1,0 +1,8 @@
+# flake8: noqa
+# pylint: disable=useless-import-alias,missing-module-docstring
+
+from .translate import TranslateTag
+
+__all__ = [
+    "TranslateTag",
+]

--- a/liquid_babel/tags/translate.py
+++ b/liquid_babel/tags/translate.py
@@ -169,6 +169,8 @@ class TranslateTag(Tag):
         expect(stream, TOKEN_COLON)
         stream.next_token()  # Eat colon
 
+        # TODO: support "simple" filters without arguments
+
         val = parse_expression(stream)
         stream.next_token()
 

--- a/liquid_babel/tags/translate.py
+++ b/liquid_babel/tags/translate.py
@@ -1,0 +1,12 @@
+from liquid.ast import Node
+from liquid.tag import Tag
+
+from liquid_babel.messages.extract import TranslatableTag
+
+
+class TranslateTag(Tag):
+    pass
+
+
+class TranslateNode(Node, TranslatableTag):
+    pass

--- a/liquid_babel/tags/translate.py
+++ b/liquid_babel/tags/translate.py
@@ -1,12 +1,317 @@
+from __future__ import annotations
+
+import itertools
+import sys
+
+from functools import partial
+from gettext import NullTranslations
+
+from typing import Any
+from typing import TYPE_CHECKING
+from typing import cast
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import NamedTuple
+from typing import Optional
+from typing import TextIO
+from typing import Tuple
+
+from liquid.ast import ChildNode
 from liquid.ast import Node
+from liquid.ast import BlockNode
+
+from liquid.context import Context
+from liquid.expression import Expression
+from liquid.limits import to_int
+
+from liquid.lex import include_expression_rules
+from liquid.lex import _compile_rules
+from liquid.lex import _tokenize
+
+from liquid.parse import expect
+from liquid.parse import get_parser
+from liquid.parse import parse_expression
+from liquid.parse import parse_unchained_identifier
+
+from liquid.stream import TokenStream
 from liquid.tag import Tag
 
+from liquid.token import Token
+from liquid.token import TOKEN_TAG
+from liquid.token import TOKEN_EXPRESSION
+from liquid.token import TOKEN_TRUE
+from liquid.token import TOKEN_FALSE
+from liquid.token import TOKEN_NIL
+from liquid.token import TOKEN_NULL
+from liquid.token import TOKEN_COLON
+from liquid.token import TOKEN_AS
+from liquid.token import TOKEN_EOF
+from liquid.token import TOKEN_COMMA
+
+from liquid_babel.messages.exceptions import TranslationKeyError
+from liquid_babel.messages.exceptions import TranslationValueError
+
+from liquid_babel.messages.translations import MessageText
 from liquid_babel.messages.translations import TranslatableTag
+from liquid_babel.messages.translations import Translations
+
+if TYPE_CHECKING:  # pragma: no cover
+    # TODO: move more imports here
+    from liquid import Environment
+
+
+TAG_TRANS = sys.intern("trans")
+TAG_ENDTRANS = sys.intern("endtrans")
+TAG_PLURAL = sys.intern("plural")
+
+trans_expression_keywords = frozenset(
+    [
+        TOKEN_TRUE,
+        TOKEN_FALSE,
+        TOKEN_NIL,
+        TOKEN_NULL,
+        TOKEN_AS,
+    ]
+)
+
+tokenize_trans_expression = partial(
+    _tokenize,
+    rules=_compile_rules(include_expression_rules),
+    keywords=trans_expression_keywords,
+)
+
+
+class TransKeywordArg(NamedTuple):
+    """A key/expression pair representing a block keyword argument."""
+
+    name: str
+    expr: Expression
+
+
+class MessageBlock(NamedTuple):
+    """The AST block, text and placeholder variables representing a message block."""
+
+    block: BlockNode
+    text: str
+    vars: List[str]
 
 
 class TranslateTag(Tag):
-    pass
+    """The "Trans" or "Translate" tag."""
+
+    name = TAG_TRANS
+    end = TAG_ENDTRANS
+    plural_name = TAG_PLURAL
+    end_block = frozenset((end, plural_name))
+
+    def __init__(self, env: Environment):
+        super().__init__(env)
+        self.parser = get_parser(self.env)
+
+    def parse(self, stream: TokenStream) -> TranslateNode:
+        expect(stream, TOKEN_TAG, value=self.name)
+        tok = stream.current
+
+        stream.next_token()
+        expect(stream, TOKEN_EXPRESSION)
+        expr_stream = TokenStream(tokenize_trans_expression(stream.current.value))
+        args = {}
+
+        while expr_stream.current.type != TOKEN_EOF:
+            key, expr = self.parse_argument(expr_stream)
+            args[key] = expr
+
+            if expr_stream.current.type == TOKEN_COMMA:
+                expr_stream.next_token()  # Eat comma
+
+        stream.next_token()
+        message_block = self.parser.parse_block(stream, self.end_block)
+        singular = self.parse_message_block(message_block)
+
+        if (
+            stream.current.type == TOKEN_TAG
+            and stream.current.value == self.plural_name
+        ):
+            stream.next_token()
+            plural_block = self.parser.parse_block(stream, (self.end,))
+            plural = self.parse_message_block(plural_block)
+        else:
+            plural = None
+
+        expect(stream, TOKEN_TAG, value=self.end)
+
+        return TranslateNode(
+            tok=tok,
+            args=args,
+            singular=singular,
+            plural=plural,
+        )
+
+    def parse_argument(self, stream: TokenStream) -> TransKeywordArg:
+        """Parse a keyword argument from a stream of tokens."""
+        key = str(parse_unchained_identifier(stream))
+        stream.next_token()
+
+        expect(stream, TOKEN_COLON)
+        stream.next_token()  # Eat colon
+
+        val = parse_expression(stream)
+        stream.next_token()
+
+        return TransKeywordArg(key, val)
+
+    def parse_message_block(self, block: BlockNode) -> MessageBlock:
+        # TODO: Raise or warn on all but output statements and literal text
+        # TODO: Raise or warn on output with filters
+        pass
 
 
 class TranslateNode(Node, TranslatableTag):
-    pass
+    """Parse tree node for the Translation block tag."""
+
+    __slots__ = (
+        "tok",
+        "args",
+        "singular",
+        "singular_block",
+        "singular_vars",
+        "plural",
+    )
+
+    default_translations = NullTranslations
+    translations_var = "translations"
+    message_count_var = "count"
+    message_context_var = "context"
+
+    def __init__(
+        self,
+        tok: Token,
+        *,
+        args: Dict[str, Expression],
+        singular: MessageBlock,
+        plural: Optional[MessageBlock],
+    ):
+        self.tok = tok
+        self.args = args
+        self.singular_block, self.singular, self.singular_vars = singular
+        self.plural = plural
+
+    def render_to_output(self, context: Context, buffer: TextIO) -> Optional[bool]:
+        translations = self.resolve_translations(context)
+        namespace = {k: v.evaluate(context) for k, v in self.args.items()}
+        count = self.resolve_count(context, namespace)
+        message_context = self.resolve_message_context(context, namespace)
+
+        with context.extend(namespace):
+            message_text, _vars = self.gettext(
+                translations,
+                count=count,
+                message_context=message_context,
+            )
+            message_vars = {v: context.resolve(v) for v in _vars}
+
+        buffer.write(self.format_message(message_text, message_vars))
+        return True
+
+    # TODO: async
+
+    def resolve_translations(self, context: Context) -> Translations:
+        """Return a translations object from the current render context."""
+        return cast(
+            Translations,
+            context.resolve(self.translations_var, self.default_translations),
+        )
+
+    def resolve_count(
+        self,
+        context: Context,  # pylint: disable=unused-argument
+        block_scope: Dict[str, object],
+    ) -> Optional[int]:
+        """Return a message count, if any, using the current render context and/or
+        the translation's block scope."""
+        try:
+            return to_int(block_scope.get(self.message_count_var, 1))  # defaults to 1
+        except ValueError:
+            return 1
+
+    def resolve_message_context(
+        self,
+        context: Context,  # pylint: disable=unused-argument
+        block_scope: Dict[str, object],
+    ) -> Optional[str]:
+        """Return the message context string, if any, using the current render
+        context and/or the translation block scope."""
+        message_context = block_scope.pop(self.message_context_var)
+        if message_context:
+            return (
+                str(message_context)
+                if not isinstance(message_context, str)
+                else message_context
+            )  # Just in case we get a Markupsafe object.
+        return None
+
+    def gettext(
+        self,
+        translations: Translations,
+        count: Optional[int],
+        message_context: Optional[str],
+    ) -> Tuple[str, Iterable[str]]:
+        """Get translated text from the given translations object."""
+        if self.plural and count:
+            if message_context:
+                text = translations.npgettext(
+                    message_context, self.singular, self.plural.text, count
+                )
+            else:
+                text = translations.ngettext(self.singular, self.plural.text, count)
+            return text, itertools.chain(self.singular_vars, self.plural.vars)
+
+        if message_context:
+            text = translations.pgettext(message_context, self.singular)
+        else:
+            text = translations.gettext(self.singular)
+        return text, self.singular_vars
+
+    def format_message(self, message_text: str, message_vars: Dict[str, Any]) -> str:
+        """Return the message string formatted with the given message variables."""
+        try:
+            return message_text % message_vars
+        except KeyError as err:
+            raise TranslationKeyError(
+                f"can't format translation message text using {message_vars!r}"
+            ) from err
+        except ValueError as err:
+            raise TranslationValueError(
+                f"can't format translation message text using {message_vars!r}"
+            ) from err
+
+    def children(self) -> List[ChildNode]:
+        children = [
+            ChildNode(
+                linenum=self.tok.linenum,
+                node=self.singular_block,
+                block_scope=list(self.args),
+            )
+        ]
+
+        if self.plural:
+            children.append(
+                ChildNode(
+                    linenum=self.plural.block.tok.linenum,
+                    node=self.plural.block,
+                    block_scope=list(self.args),
+                )
+            )
+
+        children.extend(
+            [
+                ChildNode(linenum=self.tok.linenum, expression=expr)
+                for expr in self.args.values()
+            ],
+        )
+
+        return children
+
+    def messages(self) -> Iterable[MessageText]:
+        return super().messages()

--- a/liquid_babel/tags/translate.py
+++ b/liquid_babel/tags/translate.py
@@ -229,7 +229,7 @@ class TranslateNode(Node, TranslatableTag):
         "plural",
     )
 
-    default_translations = NullTranslations
+    default_translations = NullTranslations()
     translations_var = "translations"
     message_count_var = "count"
     message_context_var = "context"
@@ -315,7 +315,7 @@ class TranslateNode(Node, TranslatableTag):
     ) -> Optional[str]:
         """Return the message context string, if any, using the current render
         context and/or the translation block scope."""
-        message_context = block_scope.pop(self.message_context_var)
+        message_context = block_scope.pop(self.message_context_var, None)
         if message_context:
             return (
                 str(message_context)

--- a/liquid_babel/tags/translate.py
+++ b/liquid_babel/tags/translate.py
@@ -1,7 +1,7 @@
 from liquid.ast import Node
 from liquid.tag import Tag
 
-from liquid_babel.messages.extract import TranslatableTag
+from liquid_babel.messages.translations import TranslatableTag
 
 
 class TranslateTag(Tag):

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     babel>=2.10.0
     pytz>=2015.7
     python-liquid>=1.4.4
+    typing-extensions>=4.2.0
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,8 +30,7 @@ python_requires = >=3.7
 install_requires =
     babel>=2.10.0
     pytz>=2015.7
-    python-liquid>=1.2.1
-    MarkupSafe>=2.0.0
+    python-liquid>=1.4.4
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,10 +26,12 @@ project_urls =
 zip_safe = False
 include_package_data = True
 packages = find:
+python_requires = >=3.7
 install_requires =
     babel>=2.10.0
     pytz>=2015.7
     python-liquid>=1.2.1
+    MarkupSafe>=2.0.0
 
 [options.packages.find]
 exclude =
@@ -52,7 +54,7 @@ warn_unused_configs = True
 warn_unused_ignores = True
 warn_return_any = True
 warn_unreachable = True
-exclude = build, dist
+exclude = build
 
 [coverage:run]
 omit = 

--- a/tests/test_message_edges.py
+++ b/tests/test_message_edges.py
@@ -1,0 +1,75 @@
+"""Test message translation edge cases."""
+# pylint: disable=missing-class-docstring,missing-function-docstring,too-many-public-methods
+import unittest
+
+from liquid import Environment
+from liquid import StrictUndefined
+
+from liquid.exceptions import UndefinedError
+
+from liquid_babel.filters.translate import register_translation_filters
+from liquid_babel.tags.translate import TranslateTag
+
+
+class MessagesEdgeTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.env = Environment()
+        register_translation_filters(self.env)
+        self.env.add_tag(TranslateTag)
+
+    def test_missing_translation_variable(self) -> None:
+        """Test that missing translation variables are `Undefined`."""
+        source = "{{ 'Hello, %(you)s!' | gettext }}"
+        template = self.env.from_string(source)
+        self.assertEqual(template.render(), "Hello, !")
+
+        self.env.undefined = StrictUndefined
+        with self.assertRaises(UndefinedError):
+            template.render()
+
+    def test_bool_translation_variable(self) -> None:
+        """Test that we handle boolean translation variables."""
+        source = "{{ 'Hello, %(you)s!' | gettext }}"
+        template = self.env.from_string(source)
+        self.assertEqual(template.render(you=True), "Hello, true!")
+
+    def test_none_translation_variable(self) -> None:
+        """Test that we handle None translation variables."""
+        source = "{{ 'Hello, %(you)s!' | gettext }}"
+        template = self.env.from_string(source)
+        self.assertEqual(template.render(you=None), "Hello, !")
+
+    def test_list_translation_variable(self) -> None:
+        """Test that we handle list translation variables."""
+        source = "{{ 'Hello, %(you)s!' | gettext }}"
+        template = self.env.from_string(source)
+        self.assertEqual(template.render(you=[1, 2, 3]), "Hello, 123!")
+
+        self.env.autoescape = True
+        self.assertEqual(template.render(you=[1, 2, 3]), "Hello, 123!")
+
+    def test_range_translation_variable(self) -> None:
+        """Test that we handle range translation variables."""
+        source = "{% assign you = (1..3) %}{{ 'Hello, %(you)s!' | gettext }}"
+        template = self.env.from_string(source)
+        self.assertEqual(template.render(), "Hello, 1..3!")
+
+        self.env.autoescape = True
+        self.assertEqual(template.render(), "Hello, 1..3!")
+
+    def test_message_not_a_string(self) -> None:
+        """Test that we handle messages that are not strings."""
+        source = "{{ true | gettext }}"
+        template = self.env.from_string(source)
+        self.assertEqual(template.render(), "true")
+
+    def test_count_not_int(self) -> None:
+        """Test that the t filter handles counts that are not ints."""
+        source = "{{ 'Hello, World!' | t: plural: 'Hello, Worlds!', count:'foo' }}"
+        template = self.env.from_string(source)
+        self.assertEqual(template.render(), "Hello, World!")
+
+
+# TODO: test chained message variables fail
+# TODO: test filtered message variables fail

--- a/tests/test_message_edges.py
+++ b/tests/test_message_edges.py
@@ -7,7 +7,7 @@ from liquid import StrictUndefined
 
 from liquid.exceptions import UndefinedError
 
-from liquid_babel.filters.translate import register_translation_filters
+from liquid_babel.filters import register_translation_filters
 from liquid_babel.messages.exceptions import TranslationSyntaxError
 from liquid_babel.tags.translate import TranslateTag
 

--- a/tests/test_message_edges.py
+++ b/tests/test_message_edges.py
@@ -69,7 +69,3 @@ class MessagesEdgeTestCase(unittest.TestCase):
         source = "{{ 'Hello, World!' | t: plural: 'Hello, Worlds!', count:'foo' }}"
         template = self.env.from_string(source)
         self.assertEqual(template.render(), "Hello, World!")
-
-
-# TODO: test chained message variables fail
-# TODO: test filtered message variables fail

--- a/tests/test_message_edges.py
+++ b/tests/test_message_edges.py
@@ -157,3 +157,23 @@ class MessagesEdgeTestCase(unittest.TestCase):
 
         template = self.env.from_string(source)
         self.assertEqual(template.render(), "Hello, World!")
+
+    def test_translate_tag_filter_arguments(self) -> None:
+        """Test that filter arguments are treated as a new tag argument."""
+        source = """
+            {%- translate you: 'World', count: collection | size: x, other: 'foo' -%}
+                Hello, {{ you }}!
+                {{ other }}
+            {%- plural -%}
+                Hello, {{ you }}s!
+                {{ other }}
+            {%- endtranslate -%}
+        """
+
+        with self.assertRaises(TranslationSyntaxError) as raised:
+            self.env.from_string(source)
+
+        self.assertEqual(
+            str(raised.exception),
+            "unexpected filter arguments in 'translate' tag, on line 2",
+        )

--- a/tests/test_message_extract.py
+++ b/tests/test_message_extract.py
@@ -1,0 +1,360 @@
+"""Test cases for translatable message extraction."""
+# pylint: disable=missing-class-docstring,missing-function-docstring
+import unittest
+
+from liquid import Environment
+from liquid import Template
+
+from liquid_babel.filters.translate import register_translation_filters
+from liquid_babel.messages.extract import extract_from_template
+
+
+class ExtractFromTemplateTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.env = Environment()
+        register_translation_filters(self.env)
+
+    def test_no_registered_filters(self) -> None:
+        """Test that we don't get messages if translation filters are not registered."""
+        source = (
+            "{{ 'Hello, World!' }}"
+            "{{ 'Hello, World!' | gettext }}"
+            "{{ 'Hello, World!' }}"
+        )
+
+        template = Template(source)
+        messages = list(extract_from_template(template))
+        self.assertEqual(len(messages), 0)
+
+    def test_gettext_filter(self) -> None:
+        """Test that we can extract messages from the GetText filter."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{{ 'Hello, World!' | gettext }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.lineno, 2)
+        self.assertEqual(message.funcname, "gettext")
+        self.assertEqual(message.message, ("Hello, World!",))
+        self.assertEqual(message.comments, [])
+
+    def test_gettext_filter_with_comment(self) -> None:
+        """Test that we can extract messages from the GetText filter with comments."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{% # Translators: greeting %}\n"
+            "{{ 'Hello, World!' | gettext }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(
+            extract_from_template(
+                template,
+                comment_tags=["Translators:"],
+            )
+        )
+
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.lineno, 3)
+        self.assertEqual(message.funcname, "gettext")
+        self.assertEqual(message.message, ("Hello, World!",))
+        self.assertEqual(message.comments, ["Translators: greeting"])
+
+    def test_preceding_comments(self) -> None:
+        """Test that comments that do no immediately precede a translatable filter
+        are excluded."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{% # Translators: greeting %}\n"
+            "\n"
+            "{{ 'Hello, World!' | gettext }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(
+            extract_from_template(
+                template,
+                comment_tags=["Translators:"],
+            )
+        )
+
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.lineno, 4)
+        self.assertEqual(message.funcname, "gettext")
+        self.assertEqual(message.message, ("Hello, World!",))
+        self.assertEqual(message.comments, [])
+
+    def test_multiple_preceding_comments(self) -> None:
+        """Test that only the last comment is included."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{% # Translators: hello %}\n"
+            "{% # Translators: greeting %}\n"
+            "{{ 'Hello, World!' | gettext }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(
+            extract_from_template(
+                template,
+                comment_tags=["Translators:"],
+            )
+        )
+
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.lineno, 4)
+        self.assertEqual(message.funcname, "gettext")
+        self.assertEqual(message.message, ("Hello, World!",))
+        self.assertEqual(message.comments, ["Translators: greeting"])
+
+    def test_comment_with_no_tag(self) -> None:
+        """Test that tag-less comments are excluded."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{% # greeting %}\n"
+            "{{ 'Hello, World!' | gettext }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(
+            extract_from_template(
+                template,
+                comment_tags=["Translators:"],
+            )
+        )
+
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.lineno, 3)
+        self.assertEqual(message.funcname, "gettext")
+        self.assertEqual(message.message, ("Hello, World!",))
+        self.assertEqual(message.comments, [])
+
+    def test_gettext_filter_excess_args(self) -> None:
+        """Test that the GetText filter handles excess arguments."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{{ 'Hello, World!' | gettext: 1 }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.lineno, 2)
+        self.assertEqual(message.funcname, "gettext")
+        self.assertEqual(message.message, ("Hello, World!",))
+        self.assertEqual(message.comments, [])
+
+    def test_ngettext_filter(self) -> None:
+        """Test that we can extract messages from the NGetText"""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{{ 'Hello, World!' | ngettext: 'Hello, Worlds!', 2 }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.lineno, 2)
+        self.assertEqual(message.funcname, "ngettext")
+        self.assertEqual(message.message, ("Hello, World!", "Hello, Worlds!"))
+        self.assertEqual(message.comments, [])
+
+    def test_ngettext_filter_too_few_args(self) -> None:
+        """Test that the NGetText handles missing arguments."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{{ 'Hello, World!' | ngettext }}\n"
+            "{{ 'Hello, World!' | ngettext: 'Hello, Worlds!' }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0].message, ("Hello, World!", "Hello, Worlds!"))
+
+    def test_ngettext_filter_too_many_args(self) -> None:
+        """Test that the NGetText handles excess arguments."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{{ 'Hello, World!' | ngettext: 'Hello, Worlds!', 2, foo }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0].message, ("Hello, World!", "Hello, Worlds!"))
+
+    def test_pgettext_filter(self) -> None:
+        """Test that we can extract messages from the NGetText."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{{ 'Hello, World!' | pgettext: 'greeting' }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.lineno, 2)
+        self.assertEqual(message.funcname, "pgettext")
+        self.assertEqual(message.message, (("greeting", "c"), "Hello, World!"))
+        self.assertEqual(message.comments, [])
+
+    def test_pgettext_filter_too_few_args(self) -> None:
+        """Test that the PGetText handles missing arguments."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{{ 'Hello, World!' | pgettext }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+        self.assertEqual(len(messages), 0)
+
+    def test_npgettext_filter(self) -> None:
+        """Test that we can extract messages from the NPGetText"""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{{ 'Hello, World!' | npgettext: 'greeting', 'Hello, Worlds!', 2 }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.lineno, 2)
+        self.assertEqual(message.funcname, "npgettext")
+        self.assertEqual(
+            message.message, (("greeting", "c"), "Hello, World!", "Hello, Worlds!")
+        )
+        self.assertEqual(message.comments, [])
+
+    def test_npgettext_filter_too_few_args(self) -> None:
+        """Test that the NPGetText handles missing arguments."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{{ 'Hello, World!' | npgettext }}\n"
+            "{{ 'Hello, World!' | npgettext: 'greeting' }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+        self.assertEqual(len(messages), 0)
+
+    def test_t_filter_gettext(self) -> None:
+        """Test that the `t` filter can behave like gettext."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{{ 'Hello, World!' | t }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.lineno, 2)
+        self.assertEqual(message.funcname, "gettext")
+        self.assertEqual(message.message, ("Hello, World!",))
+        self.assertEqual(message.comments, [])
+
+    def test_t_filter_ngettext(self) -> None:
+        """Test that the `t` filter can behave like ngettext."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{{ 'Hello, World!' | t: plural: 'Hello, Worlds!' }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.lineno, 2)
+        self.assertEqual(message.funcname, "ngettext")
+        self.assertEqual(message.message, ("Hello, World!", "Hello, Worlds!"))
+        self.assertEqual(message.comments, [])
+
+    def test_t_filter_pgettext(self) -> None:
+        """Test that the `t` filter can behave like pgettext."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{{ 'Hello, World!' | t: context: 'greeting' }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.lineno, 2)
+        self.assertEqual(message.funcname, "pgettext")
+        self.assertEqual(message.message, (("greeting", "c"), "Hello, World!"))
+        self.assertEqual(message.comments, [])
+
+    def test_t_filter_npgettext(self) -> None:
+        """Test that the `t` filter can behave like npgettext."""
+        source = (
+            "{{ 'Hello, World!' }}\n"
+            "{{ 'Hello, World!' | t: context: 'greeting', plural: 'Hello, Worlds!' }}\n"
+            "{{ 'Hello, World!' }}\n"
+        )
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+
+        self.assertEqual(len(messages), 1)
+        message = messages[0]
+
+        self.assertEqual(message.lineno, 2)
+        self.assertEqual(message.funcname, "npgettext")
+        self.assertEqual(
+            message.message, (("greeting", "c"), "Hello, World!", "Hello, Worlds!")
+        )
+        self.assertEqual(message.comments, [])

--- a/tests/test_message_extract.py
+++ b/tests/test_message_extract.py
@@ -461,6 +461,15 @@ class ExtractFromTemplateTestCase(unittest.TestCase):
         self.assertEqual(message.message, ("Hello, %(you)s!",))
         self.assertEqual(message.comments, [])
 
+    def test_empty_translate_tag(self) -> None:
+        """Test that we handle empty translate tags."""
+        source = "{% translate %}{% endtranslate %}"
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+
+        self.assertEqual(len(messages), 0)
+
     def test_translate_tag_with_comment(self) -> None:
         """Test that the `translate` tag can include a comment."""
         source = (

--- a/tests/test_message_extract.py
+++ b/tests/test_message_extract.py
@@ -537,6 +537,14 @@ class ExtractFromTemplateTestCase(unittest.TestCase):
         self.assertEqual(message.message, ("Hello, World!",))
         self.assertEqual(message.comments, [])
 
+    def test_translation_filters_must_come_first(self) -> None:
+        """Test messages with filters before t or gettext are ignored."""
+        source = "{{ 'Hello, World!' | upcase | t }}\n"
+
+        template = self.env.from_string(source)
+        messages = list(extract_from_template(template))
+        self.assertEqual(len(messages), 0)
+
 
 class BabelExtractTestCase(unittest.TestCase):
     def test_extract_liquid(self) -> None:

--- a/tests/test_message_translation.py
+++ b/tests/test_message_translation.py
@@ -11,8 +11,7 @@ from typing import List
 from liquid import Environment
 from liquid import Markup
 
-from liquid_babel.filters.translate import register_translation_filters
-
+from liquid_babel.filters import register_translation_filters
 from liquid_babel.tags.translate import TranslateTag
 
 PGETTEXT_AVAILABLE = hasattr(NullTranslations, "pgettext")

--- a/tests/test_message_translation.py
+++ b/tests/test_message_translation.py
@@ -233,7 +233,7 @@ class TranslateMessagesTestCase(unittest.TestCase):
     def test_translate_tag_ngettext(self) -> None:
         """Test that we can do ngettext with the translate tag."""
         source = """
-            {%- translate you: 'World', count: 2 -%}
+            {%- translate, you: 'World', count: 2 -%}
                 Hello, {{ you }}!
             {%- plural -%}
                 Hello, {{ you }}s!

--- a/tests/test_message_translation.py
+++ b/tests/test_message_translation.py
@@ -1,0 +1,204 @@
+"""Test cases for rendering translatable messages."""
+# pylint: disable=missing-class-docstring,missing-function-docstring,too-many-public-methods
+import re
+import unittest
+
+from typing import List
+
+from liquid import Environment
+
+from liquid_babel.filters.translate import register_translation_filters
+from liquid_babel.tags.translate import TranslateTag
+
+
+class MockTranslations:
+    """A mock translations class that returns all messages in upper case."""
+
+    RE_VARS = re.compile(r"%\(\w+\)s")
+
+    def gettext(self, message: str) -> str:
+        return self._upper(message)
+
+    def ngettext(self, singular: str, plural: str, n: int) -> str:
+        if n > 1:
+            return self._upper(plural)
+        return self._upper(singular)
+
+    def pgettext(self, message_context: str, message: str) -> str:
+        return message_context + "::" + self._upper(message)
+
+    def npgettext(
+        self, message_context: str, singular: str, plural: str, n: int
+    ) -> str:
+        if n > 1:
+            return message_context + "::" + self._upper(plural)
+        return message_context + "::" + self._upper(singular)
+
+    def _upper(self, message: str) -> str:
+        start = 0
+        parts: List[str] = []
+        for match in self.RE_VARS.finditer(message):
+            parts.append(message[start : match.start()].upper())
+            parts.append(match.group())
+            start = match.end()
+
+        parts.append(message[start:].upper())
+        return "".join(parts)
+
+
+MOCK_TRANSLATIONS = MockTranslations()
+
+
+class TranslateMessagesTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.env = Environment()
+        register_translation_filters(self.env)
+        self.env.add_tag(TranslateTag)
+
+    def test_gettext_filter(self) -> None:
+        """Test that we can translate messages with the gettext filter."""
+        source = "{{ 'Hello, World!' | gettext }}"
+        template = self.env.from_string(source)
+
+        # Default, null translation
+        result = template.render()
+        self.assertEqual(result, "Hello, World!")
+
+        # Mock translation
+        result = template.render(translations=MOCK_TRANSLATIONS)
+        self.assertEqual(result, "HELLO, WORLD!")
+
+    def test_gettext_from_context(self) -> None:
+        """Test that we can translate messages from context with the gettext filter."""
+        source = "{{ foo | gettext }}"
+        template = self.env.from_string(source)
+
+        # Default, null translation
+        result = template.render(foo="Hello, World!")
+        self.assertEqual(result, "Hello, World!")
+
+        # Mock translation
+        result = template.render(
+            translations=MOCK_TRANSLATIONS,
+            foo="Hello, World!",
+        )
+        self.assertEqual(result, "HELLO, WORLD!")
+
+    def test_gettext_filter_with_variables(self) -> None:
+        """Test that we can translate messages with the gettext filter."""
+        source = "{{ 'Hello, %(you)s!' | gettext: you: 'World' }}"
+        template = self.env.from_string(source)
+
+        # Default, null translation
+        result = template.render()
+        self.assertEqual(result, "Hello, World!")
+
+        # Mock translation
+        result = template.render(translations=MOCK_TRANSLATIONS)
+        self.assertEqual(result, "HELLO, World!")
+
+    def test_ngettext_filter(self) -> None:
+        """Test that we can translate messages with the ngettext filter."""
+        source = "{{ 'Hello, World!' | ngettext: 'Hello, Worlds!', 2 }}"
+        template = self.env.from_string(source)
+
+        # Default, null translation
+        result = template.render()
+        self.assertEqual(result, "Hello, Worlds!")
+
+        # Mock translation
+        result = template.render(translations=MOCK_TRANSLATIONS)
+        self.assertEqual(result, "HELLO, WORLDS!")
+
+    def test_pgettext_filter(self) -> None:
+        """Test that we can translate messages with the pgettext filter."""
+        source = "{{ 'Hello, World!' | pgettext: 'greeting' }}"
+        template = self.env.from_string(source)
+
+        # Default, null translation
+        result = template.render()
+        self.assertEqual(result, "Hello, World!")
+
+        # Mock translation
+        result = template.render(translations=MOCK_TRANSLATIONS)
+        self.assertEqual(result, "greeting::HELLO, WORLD!")
+
+    def test_npgettext_filter(self) -> None:
+        """Test that we can translate messages with the npgettext filter."""
+        source = "{{ 'Hello, World!' | npgettext: 'greeting', 'Hello, Worlds!', 2 }}"
+        template = self.env.from_string(source)
+
+        # Default, null translation
+        result = template.render()
+        self.assertEqual(result, "Hello, Worlds!")
+
+        # Mock translation
+        result = template.render(translations=MOCK_TRANSLATIONS)
+        self.assertEqual(result, "greeting::HELLO, WORLDS!")
+
+    def test_t_filter_gettext(self) -> None:
+        """Test that we can do gettext with the t filter."""
+        source = "{{ 'Hello, World!' | t }}"
+        template = self.env.from_string(source)
+
+        # Default, null translation
+        result = template.render()
+        self.assertEqual(result, "Hello, World!")
+
+        # Mock translation
+        result = template.render(translations=MOCK_TRANSLATIONS)
+        self.assertEqual(result, "HELLO, WORLD!")
+
+    def test_t_filter_ngettext(self) -> None:
+        """Test that we can do ngettext with the t filter."""
+        source = "{{ 'Hello, World!' | t: plural: 'Hello, Worlds!', count: 2 }}"
+        template = self.env.from_string(source)
+
+        # Default, null translation
+        result = template.render()
+        self.assertEqual(result, "Hello, Worlds!")
+
+        # Mock translation
+        result = template.render(translations=MOCK_TRANSLATIONS)
+        self.assertEqual(result, "HELLO, WORLDS!")
+
+    def test_t_filter_pgettext(self) -> None:
+        """Test that we can do pgettext with the t filter."""
+        source = "{{ 'Hello, %(you)s!' | t: 'greeting', you: 'World' }}"
+        template = self.env.from_string(source)
+
+        # Default, null translation
+        result = template.render()
+        self.assertEqual(result, "Hello, World!")
+
+        # Mock translation
+        result = template.render(translations=MOCK_TRANSLATIONS)
+        self.assertEqual(result, "greeting::HELLO, World!")
+
+    def test_t_filter_npgettext(self) -> None:
+        """Test that we can do npgettext with the t filter."""
+        source = """
+            {{-
+                'Hello, %(you)s!' | t:
+                    'greeting',
+                    plural: 'Hello, %(you)ss!',
+                    count: 2,
+                    you: 'World'
+            -}}
+        """
+        template = self.env.from_string(source)
+
+        # Default, null translation
+        result = template.render()
+        self.assertEqual(result, "Hello, Worlds!")
+
+        # Mock translation
+        result = template.render(translations=MOCK_TRANSLATIONS)
+        self.assertEqual(result, "greeting::HELLO, WorldS!")
+
+
+# TODO: test turn off filter message interpolation
+# TODO: test plural is converted to a string
+# TODO: test ngettext count can be a string
+# TODO: test autoescape

--- a/tests/test_message_translation.py
+++ b/tests/test_message_translation.py
@@ -7,7 +7,9 @@ from typing import List
 
 from liquid import Environment
 
+from liquid_babel.filters.translate import PGETTEXT_AVAILABLE
 from liquid_babel.filters.translate import register_translation_filters
+
 from liquid_babel.tags.translate import TranslateTag
 
 
@@ -111,6 +113,7 @@ class TranslateMessagesTestCase(unittest.TestCase):
         result = template.render(translations=MOCK_TRANSLATIONS)
         self.assertEqual(result, "HELLO, WORLDS!")
 
+    @unittest.skipUnless(PGETTEXT_AVAILABLE, "pgettext was new in python 3.8")
     def test_pgettext_filter(self) -> None:
         """Test that we can translate messages with the pgettext filter."""
         source = "{{ 'Hello, World!' | pgettext: 'greeting' }}"
@@ -124,6 +127,7 @@ class TranslateMessagesTestCase(unittest.TestCase):
         result = template.render(translations=MOCK_TRANSLATIONS)
         self.assertEqual(result, "greeting::HELLO, WORLD!")
 
+    @unittest.skipUnless(PGETTEXT_AVAILABLE, "pgettext was new in python 3.8")
     def test_npgettext_filter(self) -> None:
         """Test that we can translate messages with the npgettext filter."""
         source = "{{ 'Hello, World!' | npgettext: 'greeting', 'Hello, Worlds!', 2 }}"
@@ -163,6 +167,7 @@ class TranslateMessagesTestCase(unittest.TestCase):
         result = template.render(translations=MOCK_TRANSLATIONS)
         self.assertEqual(result, "HELLO, WORLDS!")
 
+    @unittest.skipUnless(PGETTEXT_AVAILABLE, "pgettext was new in python 3.8")
     def test_t_filter_pgettext(self) -> None:
         """Test that we can do pgettext with the t filter."""
         source = "{{ 'Hello, %(you)s!' | t: 'greeting', you: 'World' }}"
@@ -176,6 +181,7 @@ class TranslateMessagesTestCase(unittest.TestCase):
         result = template.render(translations=MOCK_TRANSLATIONS)
         self.assertEqual(result, "greeting::HELLO, World!")
 
+    @unittest.skipUnless(PGETTEXT_AVAILABLE, "pgettext was new in python 3.8")
     def test_t_filter_npgettext(self) -> None:
         """Test that we can do npgettext with the t filter."""
         source = """

--- a/tests/test_message_translation.py
+++ b/tests/test_message_translation.py
@@ -5,15 +5,17 @@ import asyncio
 import re
 import unittest
 
+from gettext import NullTranslations
 from typing import List
 
 from liquid import Environment
 from liquid import Markup
 
-from liquid_babel.filters.translate import PGETTEXT_AVAILABLE
 from liquid_babel.filters.translate import register_translation_filters
 
 from liquid_babel.tags.translate import TranslateTag
+
+PGETTEXT_AVAILABLE = hasattr(NullTranslations, "pgettext")
 
 
 class MockTranslations:

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ isolated_build = True
 [testenv]
 deps = 
     pytest
+    markupsafe
 commands = pytest -v --tb=short --basetemp={envtmpdir} {posargs}
 
 [testenv:typing]
@@ -16,6 +17,7 @@ deps =
     mypy
     types-babel
     types-python-dateutil
+    types-MarkupSafe
 commands = mypy
 
 [testenv:lint]
@@ -24,7 +26,9 @@ deps =
 commands = python -m pylint -rn tests/ liquid_babel/
 
 [testenv:coverage]
-deps = coverage
+deps = 
+    coverage
+    markupsafe
 commands = 
     python -m coverage run -m unittest
     python -m coverage report --fail-under=98


### PR DESCRIPTION
This pull requests adds Liquid filters and tags for translatable messages. We also define a [Babel](https://babel.pocoo.org/en/latest/index.html) compatible message extraction function.

The new filters are equivalent to `gettext`, `ngettext`, `pgettext` and `npgettext` functions from the `gettext` module, as well as a `t` filter that can behave like any of these depending on its arguments.

The new `translate` or `trans` tag is similar to [Django's `blocktranslate` tag](https://docs.djangoproject.com/en/4.1/topics/i18n/translation/#blocktranslate-template-tag) or [Jinja's `trans` tag](https://jinja.palletsprojects.com/en/3.1.x/templates/#i18n).